### PR TITLE
Dashboard event

### DIFF
--- a/src/elements/input/input.svelte
+++ b/src/elements/input/input.svelte
@@ -14,7 +14,7 @@
 	export let value: string | number = '';
 </script>
 
-<div class="{classes}">
+<div class={classes}>
 	<Label for_={id}>{labelText}</Label>
 	<input
 		class="normal-font"
@@ -25,6 +25,7 @@
 		bind:value
 		on:input
 		aria-label={ariaLabel}
+		step="1"
 	/>
 </div>
 

--- a/src/elements/navigation/manualUnsavedChangesPopup.svelte
+++ b/src/elements/navigation/manualUnsavedChangesPopup.svelte
@@ -62,7 +62,7 @@
 			{#if saveButton}
 				<Button
 					on:click={saveAsync}
-					ariaLabel="Klicke hier, um die Änderungen zu Speichern und die Seite zu verlassen"
+					ariaLabel="Klicke hier, um die Änderungen zu speichern und die Seite zu verlassen"
 				>
 					Speichern und Verlassen
 				</Button>

--- a/src/elements/navigation/manualUnsavedChangesPopup.svelte
+++ b/src/elements/navigation/manualUnsavedChangesPopup.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+	import { fade } from 'svelte/transition';
+	import { saveCallback } from 'stores/saveCallback';
+	import { resetUnsavedChanges } from 'stores/saved';
+
+	import Button from 'elements/input/button.svelte';
+	import SubHeadline from 'elements/text/subHeadline.svelte';
+
+	export let stayCallback: () => void;
+	export let navigateCallback: () => void;
+
+	let _show: boolean = false;
+	let saveButton: boolean = false;
+
+	export function show(): void {
+		saveButton = checkSaveButton();
+		_show = true;
+	}
+	export function hide(): void {
+		_show = false;
+	}
+
+	function checkSaveButton(): boolean {
+		const returnValue = saveCallback();
+		return typeof returnValue === 'function';
+	}
+
+	function stay(): void {
+		hide();
+		stayCallback();
+	}
+	function navigate(): void {
+		resetUnsavedChanges();
+		hide();
+		navigateCallback();
+	}
+
+	async function saveAsync(): Promise<void> {
+		const callback = saveCallback();
+		if (callback) {
+			const result = await callback();
+			if (result) {
+				navigate();
+				return;
+			}
+			stay();
+			return;
+		}
+
+		console.error('not able to call callback in unsaved changes popup');
+		stay();
+	}
+</script>
+
+<dialog open={_show} on:click={stay} role="presentation" transition:fade={{ duration: 300 }}>
+	<div class="unsaved-changes-modal" on:click={(e) => e.stopPropagation()} role="presentation">
+		<SubHeadline classes="white">Es gibt ungespeicherte Änderungen</SubHeadline>
+		<div class="unsaved-changes-button-wrapper">
+			<Button on:click={stay} ariaLabel="Klicke hier, um auf der Seite zu bleiben">
+				Auf Seite bleiben
+			</Button>
+			{#if saveButton}
+				<Button
+					on:click={saveAsync}
+					ariaLabel="Klicke hier, um die Änderungen zu Speichern und die Seite zu verlassen"
+				>
+					Speichern und Verlassen
+				</Button>
+			{/if}
+			<Button on:click={navigate} ariaLabel="Klicke hier, um die Seite zu verlassen">
+				Seite verlassen
+			</Button>
+		</div>
+	</div>
+</dialog>
+
+<style>
+	dialog {
+		top: 0;
+		left: 0;
+		height: 100vh;
+		width: 100vw;
+		background-color: var(--background-color-transparent);
+		z-index: 20;
+		justify-content: center;
+		align-items: center;
+	}
+
+	dialog[open] {
+		display: flex;
+	}
+
+	.unsaved-changes-modal {
+		display: flex;
+		flex-direction: column;
+		background-color: var(--background-color-light);
+		padding: var(--2x-padding);
+		border: 1px solid var(--line-color);
+		border-radius: var(--border-radius);
+		gap: var(--full-gap);
+		align-items: center;
+	}
+
+	.unsaved-changes-button-wrapper {
+		display: flex;
+		flex-direction: row;
+		gap: var(--full-gap);
+	}
+</style>

--- a/src/elements/navigation/unsavedChangesCallbackWrapper.svelte
+++ b/src/elements/navigation/unsavedChangesCallbackWrapper.svelte
@@ -2,16 +2,15 @@
 	type AsyncCallback = () => Promise<boolean>;
 
 	import { onDestroy, onMount } from 'svelte';
-	import UnsavedChangesPopup from './unsavedChangesPopup.svelte';
+	import { setSaveCallback, resetSaveCallback } from 'stores/saveCallback';
 
-	export let component: UnsavedChangesPopup;
 	export let callback: AsyncCallback;
 
 	onMount(() => {
-		component.callback = callback;
+		setSaveCallback(callback);
 	});
 
 	onDestroy(() => {
-		component.callback = undefined;
+		resetSaveCallback();
 	});
 </script>

--- a/src/elements/navigation/unsavedChangesCallbackWrapper.svelte
+++ b/src/elements/navigation/unsavedChangesCallbackWrapper.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	type AsyncCallback = () => Promise<boolean>;
+
+	import { onDestroy, onMount } from 'svelte';
+	import UnsavedChangesPopup from './unsavedChangesPopup.svelte';
+
+	export let component: UnsavedChangesPopup;
+	export let callback: AsyncCallback;
+
+	onMount(() => {
+		component.callback = callback;
+	});
+
+	onDestroy(() => {
+		component.callback = undefined;
+	});
+</script>

--- a/src/elements/navigation/unsavedChangesPopup.svelte
+++ b/src/elements/navigation/unsavedChangesPopup.svelte
@@ -37,10 +37,10 @@
 			</Button>
 			<Button
 				on:click={() => {
-				intercepted = null;
-				resetUnsavedChanges();
-				goto(url);
-			}}
+					intercepted = null;
+					resetUnsavedChanges();
+					goto(url);
+				}}
 				ariaLabel="Klicke hier, um die Seite zu verlassen"
 			>
 				Seite verlassen
@@ -50,35 +50,35 @@
 </dialog>
 
 <style>
-    dialog {
-        top: 0;
-        left: 0;
-        height: 100vh;
-        width: 100vw;
-        background-color: var(--background-color-transparent);
-        z-index: 20;
-        justify-content: center;
-        align-items: center;
-    }
+	dialog {
+		top: 0;
+		left: 0;
+		height: 100vh;
+		width: 100vw;
+		background-color: var(--background-color-transparent);
+		z-index: 20;
+		justify-content: center;
+		align-items: center;
+	}
 
-    dialog[open] {
-        display: flex;
-    }
+	dialog[open] {
+		display: flex;
+	}
 
-    .unsaved-changes-modal {
-        display: flex;
-        flex-direction: column;
-        background-color: var(--background-color-light);
-        padding: var(--2x-padding);
-        border: 1px solid var(--line-color);
-        border-radius: var(--border-radius);
-				gap: var(--full-gap);
-				align-items: center;
-    }
+	.unsaved-changes-modal {
+		display: flex;
+		flex-direction: column;
+		background-color: var(--background-color-light);
+		padding: var(--2x-padding);
+		border: 1px solid var(--line-color);
+		border-radius: var(--border-radius);
+		gap: var(--full-gap);
+		align-items: center;
+	}
 
-    .unsaved-changes-button-wrapper {
-        display: flex;
-        flex-direction: row;
-        gap: var(--full-gap);
-    }
+	.unsaved-changes-button-wrapper {
+		display: flex;
+		flex-direction: row;
+		gap: var(--full-gap);
+	}
 </style>

--- a/src/elements/navigation/unsavedChangesPopup.svelte
+++ b/src/elements/navigation/unsavedChangesPopup.svelte
@@ -71,7 +71,7 @@
 			{#if saveButton}
 				<Button
 					on:click={saveAsync}
-					ariaLabel="Klicke hier, um die Änderungen zu Speichern und die Seite zu verlassen"
+					ariaLabel="Klicke hier, um die Änderungen zu speichern und die Seite zu verlassen"
 				>
 					Speichern und Verlassen
 				</Button>

--- a/src/elements/navigation/unsavedChangesPopup.svelte
+++ b/src/elements/navigation/unsavedChangesPopup.svelte
@@ -1,3 +1,8 @@
+<script lang="ts" context="module">
+	type AsyncCallback = () => Promise<boolean>;
+	export let callback: AsyncCallback | undefined = undefined;
+</script>
+
 <script lang="ts">
 	import { resetUnsavedChanges, unsavedChanges } from 'stores/saved';
 	import { beforeNavigate, goto } from '$app/navigation';

--- a/src/elements/navigation/unsavedChangesPopup.svelte
+++ b/src/elements/navigation/unsavedChangesPopup.svelte
@@ -58,7 +58,7 @@
 
 <dialog
 	open={intercepted !== null}
-	on:click={() => (intercepted = null)}
+	on:click={stay}
 	role="presentation"
 	transition:fade={{ duration: 300 }}
 >

--- a/src/elements/schedule/schedule.svelte
+++ b/src/elements/schedule/schedule.svelte
@@ -19,7 +19,7 @@
 		}
 
 		console.error(`error while looking up speaker with ID ${id}.`);
-		throw error(404);
+		throw error(500);
 	}
 </script>
 
@@ -60,8 +60,8 @@
 	}
 
 	@media (max-width: 600px) {
-			.schedule-element-day {
-					grid-template-columns: 8rem 1fr;
-			}
-  }
+		.schedule-element-day {
+			grid-template-columns: 8rem 1fr;
+		}
+	}
 </style>

--- a/src/helper/dates.ts
+++ b/src/helper/dates.ts
@@ -23,9 +23,11 @@ export function formatDate(provided: string, format: string): string {
         '%hh': String(date.getHours()).padStart(2, '0'),
         '%m': String(date.getMinutes()),
         '%mm': String(date.getMinutes()).padStart(2, '0'),
+        '%s': String(date.getSeconds()),
+        '%ss': String(date.getSeconds()).padStart(2, '0'),
     };
 
-    return format.replace(/%YYYY|%MM|%M|%DD|%D|%d|%hh|%h|%mm|%m/g, matched => map[matched]);
+    return format.replace(/%YYYY|%MM|%M|%DD|%D|%d|%hh|%h|%mm|%m|%ss|%s/g, matched => map[matched]);
 }
 
 

--- a/src/helper/dates.ts
+++ b/src/helper/dates.ts
@@ -1,8 +1,3 @@
-export type TimeDate = {
-    date: string;
-    time: string;
-};
-
 const lookup: string[] = [
     'Sonntag',
     'Montag',
@@ -38,6 +33,9 @@ export function convertTimeAndDateToHTML(timeAndDate: string): string {
     return timeAndDate.replace(' ', 'T');
 }
 
-export function convertTimeAndDateToSQL(timeAndDate: string): string {
+export function convertTimeAndDateToSQL(timeAndDate: string | null): string | null {
+    if (!timeAndDate) {
+        return null;
+    }
     return timeAndDate.replace('T', ' ');
 }

--- a/src/helper/dates.ts
+++ b/src/helper/dates.ts
@@ -54,3 +54,11 @@ export function checkSQLTimeAndDate(timeAndDate: string | null): string | null {
 
     return timeAndDate;
 }
+
+export function isBeforeOrSameDatesString(lhs: string, rhs: string): boolean {
+    return isBeforeOrSameDates(new Date(lhs), new Date(rhs));
+}
+
+export function isBeforeOrSameDates(lhs: Date, rhs: Date): boolean {
+    return lhs.getTime() <= rhs.getTime();
+}

--- a/src/helper/dates.ts
+++ b/src/helper/dates.ts
@@ -41,3 +41,16 @@ export function convertTimeAndDateToSQL(timeAndDate: string | null): string | nu
     }
     return timeAndDate.replace('T', ' ');
 }
+
+export function checkSQLTimeAndDate(timeAndDate: string | null): string | null {
+    if (!timeAndDate) {
+        return null;
+    }
+
+    const reference: string = 'YYYY-MM-DDThh:mm:ss';
+    if (timeAndDate.length < reference.length) {
+        timeAndDate += ":00";
+    }
+
+    return timeAndDate;
+}

--- a/src/helper/dates.ts
+++ b/src/helper/dates.ts
@@ -34,21 +34,10 @@ export function formatDate(provided: string, format: string): string {
 }
 
 
-export function splitTimeAndDate(timeAndDate: string): TimeDate {
-    const split = timeAndDate.split(' ');
-    if (split.length !== 2) {
-        console.log('not able to split date and time properly');
-        return {
-            date: "",
-            time: "",
-        }
-    }
-    return {
-        date: split[0],
-        time: split[1],
-    }
+export function convertTimeAndDateToHTML(timeAndDate: string): string {
+    return timeAndDate.replace(' ', 'T');
 }
 
-export function combineTimeAndDate(timeAndDate: TimeDate): string {
-    return `${timeAndDate.date} ${timeAndDate.time}`;
+export function convertTimeAndDateToSQL(timeAndDate: string): string {
+    return timeAndDate.replace('T', ' ');
 }

--- a/src/helper/dates.ts
+++ b/src/helper/dates.ts
@@ -1,3 +1,8 @@
+export type TimeDate = {
+    date: string;
+    time: string;
+};
+
 const lookup: string[] = [
     'Sonntag',
     'Montag',
@@ -26,4 +31,24 @@ export function formatDate(provided: string, format: string): string {
     };
 
     return format.replace(/%YYYY|%MM|%M|%DD|%D|%d|%hh|%h|%mm|%m/g, matched => map[matched]);
+}
+
+
+export function splitTimeAndDate(timeAndDate: string): TimeDate {
+    const split = timeAndDate.split(' ');
+    if (split.length !== 2) {
+        console.log('not able to split date and time properly');
+        return {
+            date: "",
+            time: "",
+        }
+    }
+    return {
+        date: split[0],
+        time: split[1],
+    }
+}
+
+export function combineTimeAndDate(timeAndDate: TimeDate): string {
+    return `${timeAndDate.date} ${timeAndDate.time}`;
 }

--- a/src/helper/loggedIn.ts
+++ b/src/helper/loggedIn.ts
@@ -19,8 +19,8 @@ export async function redirectIfUnauthorizedOrReteturnRolesAsync(fetch: Function
     const roles: DashboardRoles = await checkAndParseInputDataAsync<DashboardRoles>(
         response,
         dashboardRolesScheme,
-        `Serveranfrage für roles nicht erfolgreich. throw error(404)`,
-        `Unerwartete Daten für roles. throw error(404)`
+        `Serveranfrage für roles nicht erfolgreich. throw error(406)`,
+        `Unerwartete Daten für roles. throw error(406)`
     );
 
     return roles;

--- a/src/helper/parseJson.ts
+++ b/src/helper/parseJson.ts
@@ -25,14 +25,14 @@ export async function parseProvidedJsonAsync<T>(response: Response, scheme: ZodT
 export async function checkAndParseInputDataAsync<T>(response: Response, scheme: ZodType<T>, messageOK: string, messageData: string): Promise<T> {
     if (!response.ok) {
         console.error(messageOK);
-        throw error(404);
+        throw error(406);
     }
 
     const data = await parseProvidedJsonAsync<T>(response, scheme);
 
     if (!data) {
         console.error(messageData);
-        throw error(404);
+        throw error(406);
     }
 
     return data;
@@ -42,7 +42,7 @@ export async function checkAndParseGlobalsAsync(response: Response): Promise<Glo
     return await checkAndParseInputDataAsync<Globals>(
         response,
         globalsScheme,
-        `Serveranfrage für globals nicht erfolgreich. throw error(404)`,
-        `Unerwartete Daten für globals. throw error(404)`
+        `Serveranfrage für globals nicht erfolgreich. throw error(406)`,
+        `Unerwartete Daten für globals. throw error(406)`
     );
 }

--- a/src/helper/scroll.ts
+++ b/src/helper/scroll.ts
@@ -1,10 +1,10 @@
 
 export function scrollToTop(): void {
-    scrollToHash('top');
+    scrollToAnchor('top');
 }
 
 
-export function scrollToHash(hash: string): void {
+export function scrollToAnchor(hash: string): void {
     window.location.hash = ""; // this is needed to get a reaction if the hash was alredy applied
     window.location.hash = hash;
 }

--- a/src/helper/scroll.ts
+++ b/src/helper/scroll.ts
@@ -1,0 +1,10 @@
+
+export function scrollToTop(): void {
+    scrollToHash('top');
+}
+
+
+export function scrollToHash(hash: string): void {
+    window.location.hash = ""; // this is needed to get a reaction if the hash was alredy applied
+    window.location.hash = hash;
+}

--- a/src/helper/trySaveDashboardData.ts
+++ b/src/helper/trySaveDashboardData.ts
@@ -14,7 +14,7 @@ export async function trySaveDashboardDataAsync<T>(data: T, url: string): Promis
     }
 
     if (import.meta.env.DEV) {
-        console.log(await response.json());
+        console.error(await response.json());
     }
 
     return SaveMessageType.Error;

--- a/src/helper/trySaveDashboardData.ts
+++ b/src/helper/trySaveDashboardData.ts
@@ -2,13 +2,13 @@ import { resetUnsavedChanges } from "stores/saved";
 import { apiUrl } from "./links";
 import { SaveMessageType } from "types/saveMessageType";
 
-export async function trySaveDashboardDataAsync<T>(data: T, url: string): Promise<SaveMessageType> {
+export async function trySaveDashboardDataAsync<T>(data: T, url: string, routeType: string = 'PUT'): Promise<SaveMessageType> {
     if (import.meta.env.DEV) {
         console.log(data);
     }
 
     const response: Response = await fetch(apiUrl(url), {
-        method: 'PUT',
+        method: routeType,
         body: JSON.stringify(data),
     });
 

--- a/src/helper/trySaveDashboardData.ts
+++ b/src/helper/trySaveDashboardData.ts
@@ -3,6 +3,10 @@ import { apiUrl } from "./links";
 import { SaveMessageType } from "types/saveMessageType";
 
 export async function trySaveDashboardDataAsync<T>(data: T, url: string): Promise<SaveMessageType> {
+    if (import.meta.env.DEV) {
+        console.log(data);
+    }
+
     const response: Response = await fetch(apiUrl(url), {
         method: 'PUT',
         body: JSON.stringify(data),

--- a/src/helper/trySaveDashboardData.ts
+++ b/src/helper/trySaveDashboardData.ts
@@ -13,5 +13,9 @@ export async function trySaveDashboardDataAsync<T>(data: T, url: string): Promis
         return SaveMessageType.Save;
     }
 
+    if (import.meta.env.DEV) {
+        console.log(await response.json());
+    }
+
     return SaveMessageType.Error;
 }

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -23,7 +23,7 @@
 		};
 
 		try {
-			// don't use `checkAndParseInputDataAsync<T>()` here because that could cause an `throw error(404)` loop
+			// don't use `checkAndParseInputDataAsync<T>()` here because that could cause an `throw error(406)` loop
 			const response: Response = await fetch(apiUrl('/api/globals'));
 			if (!response.ok) {
 				await handleFail(response);

--- a/src/routes/dashboard/+layout.svelte
+++ b/src/routes/dashboard/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { LoadDashboard } from 'types/loadTypes';
+	import type { LoadDashboard } from 'types/dashboardLoadTypes';
 
 	import * as Menu from 'menu/dashboard';
 	import Header from 'elements/navigation/header.svelte';
@@ -41,13 +41,13 @@
 </div>
 
 <style>
-    .dashboard-wrapper {
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        margin: 0 auto;
-        min-height: 100vh;
-    }
+	.dashboard-wrapper {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		margin: 0 auto;
+		min-height: 100vh;
+	}
 
 	.dashboard-section-wrapper {
 		display: flex;

--- a/src/routes/dashboard/+layout.svelte
+++ b/src/routes/dashboard/+layout.svelte
@@ -11,6 +11,7 @@
 	import { unsavedChanges, resetUnsavedChanges } from 'stores/saved';
 
 	export let data: LoadDashboard; // data from database
+	let unsavedChangesPopup: UnsavedChangesPopup;
 
 	onMount(() => {
 		resetUnsavedChanges();
@@ -22,7 +23,7 @@
 	});
 </script>
 
-<UnsavedChangesPopup />
+<UnsavedChangesPopup bind:this={unsavedChangesPopup} />
 <Header menu={Menu.headerIn} />
 <div class="dashboard-wrapper">
 	<div class="dashboard-section-wrapper">
@@ -34,7 +35,7 @@
 		/>
 	</div>
 	<div class="dashboard-content">
-		<slot />
+		<slot {unsavedChangesPopup} />
 	</div>
 
 	<Footer menu={Menu.footerIn} globals={data.globals} />

--- a/src/routes/dashboard/+layout.svelte
+++ b/src/routes/dashboard/+layout.svelte
@@ -11,7 +11,6 @@
 	import { unsavedChanges, resetUnsavedChanges } from 'stores/saved';
 
 	export let data: LoadDashboard; // data from database
-	let unsavedChangesPopup: UnsavedChangesPopup;
 
 	onMount(() => {
 		resetUnsavedChanges();
@@ -23,7 +22,7 @@
 	});
 </script>
 
-<UnsavedChangesPopup bind:this={unsavedChangesPopup} />
+<UnsavedChangesPopup />
 <Header menu={Menu.headerIn} />
 <div class="dashboard-wrapper">
 	<div class="dashboard-section-wrapper">
@@ -35,7 +34,7 @@
 		/>
 	</div>
 	<div class="dashboard-content">
-		<slot {unsavedChangesPopup} />
+		<slot />
 	</div>
 
 	<Footer menu={Menu.footerIn} globals={data.globals} />

--- a/src/routes/dashboard/admin/+layout.svelte
+++ b/src/routes/dashboard/admin/+layout.svelte
@@ -3,6 +3,9 @@
 
 	import Tabs from 'elements/navigation/tabs.svelte';
 	import Headline from 'elements/text/headline.svelte';
+	import UnsavedChangesPopup from 'elements/navigation/unsavedChangesPopup.svelte';
+
+	export let unsavedChangesPopup: UnsavedChangesPopup;
 
 	const tabsEntries: Menu = [
 		{
@@ -22,7 +25,7 @@
 	<Headline classes="headline-border">Admin</Headline>
 	<Tabs entries={tabsEntries} />
 </div>
-<slot />
+<slot {unsavedChangesPopup} />
 
 <style>
 	.dashboard-admin {

--- a/src/routes/dashboard/admin/+layout.svelte
+++ b/src/routes/dashboard/admin/+layout.svelte
@@ -3,9 +3,6 @@
 
 	import Tabs from 'elements/navigation/tabs.svelte';
 	import Headline from 'elements/text/headline.svelte';
-	import UnsavedChangesPopup from 'elements/navigation/unsavedChangesPopup.svelte';
-
-	export let unsavedChangesPopup: UnsavedChangesPopup;
 
 	const tabsEntries: Menu = [
 		{
@@ -25,7 +22,7 @@
 	<Headline classes="headline-border">Admin</Headline>
 	<Tabs entries={tabsEntries} />
 </div>
-<slot {unsavedChangesPopup} />
+<slot />
 
 <style>
 	.dashboard-admin {

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -7,7 +7,7 @@
 	import { onMount } from 'svelte';
 	import { Clone } from 'helper/clone';
 	import { isSaveType } from 'types/saveMessageType';
-	import { getAllEventTitle, getEventByTitle, validateData } from './eventsHelper';
+	import { convertSaveData, getAllEventTitle, getEventByTitle, validateData } from './eventsHelper';
 	import { unsavedChanges, setUnsavedChanges } from 'stores/saved';
 	import {
 		checkSQLTimeAndDate,
@@ -112,13 +112,7 @@
 	}
 
 	async function trySaveAsync(): Promise<boolean> {
-		const toSave: SetAdminEvent = structuredClone(currentEvent);
-		toSave.publish_date = checkSQLTimeAndDate(convertTimeAndDateToSQL(toSave.publish_date));
-		toSave.schedule_visible_from = checkSQLTimeAndDate(
-			convertTimeAndDateToSQL(toSave.schedule_visible_from)
-		);
-		toSave.start_date = toSave.start_date;
-		toSave.end_date = toSave.end_date;
+		const toSave: SetAdminEvent = convertSaveData(structuredClone(currentEvent));
 
 		scrollToTop(); // scroll here already so that all error messages can be seen.
 

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -9,12 +9,7 @@
 	import { isSaveType } from 'types/saveMessageType';
 	import { convertSaveData, getAllEventTitle, getEventByTitle, validateData } from './eventsHelper';
 	import { unsavedChanges, setUnsavedChanges } from 'stores/saved';
-	import {
-		checkSQLTimeAndDate,
-		convertTimeAndDateToHTML,
-		convertTimeAndDateToSQL,
-		formatDate
-	} from 'helper/dates';
+	import { convertTimeAndDateToHTML, formatDate } from 'helper/dates';
 	import { trySaveDashboardDataAsync } from 'helper/trySaveDashboardData';
 	import { scrollToTop } from 'helper/scroll';
 

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -1,36 +1,70 @@
 <script lang="ts">
 	import type { LoadAdminEvents, LoadDashboard } from 'types/dashboardLoadTypes';
+	import type { DashboardEvent } from 'types/dashboardProvideTypes';
 
 	import { Clone } from 'helper/clone';
-	import { getDropDownKeys } from './eventsHelper';
+	import { getAllEventTitle, getEventByTitle } from './eventsHelper';
+	import { unsavedChanges } from 'stores/saved';
+	import { onMount } from 'svelte';
 
 	import TextLine from 'elements/text/textLine.svelte';
 	import SaveMessage from 'elements/text/saveMessage.svelte';
 	import SectionDashboard from 'elements/section/sectionDashboard.svelte';
 	import DropDown from 'elements/input/dropDown.svelte';
+	import SubHeadline from 'elements/text/subHeadline.svelte';
 
 	export let data: LoadDashboard & LoadAdminEvents;
 	let copiedData = new Clone<LoadDashboard & LoadAdminEvents>(data);
 	let message: SaveMessage;
 	let selected: string;
+	let displayed: string;
+	let currentEvent: DashboardEvent;
+
+	onMount(() => {
+		updateDisplayed();
+	});
+
+	function updateDisplayed(): void {
+		if (unsavedChanges()) {
+			console.log('unsaved changes');
+			selected = displayed;
+			return;
+		}
+
+		displayed = selected;
+		currentEvent = getEventByTitle(copiedData.value.allEvents, displayed);
+	}
 </script>
 
 <SectionDashboard classes="dashboard-admin-event-section">
 	<SaveMessage bind:this={message} />
 	{#if copiedData.value.allEvents}
 		<DropDown
-			data={getDropDownKeys(copiedData.value.allEvents)}
+			data={getAllEventTitle(copiedData.value.allEvents)}
 			bind:selected
 			id={'dashboard-admin-event-drop-down'}
 			labelText="Aktuelles Event:"
+			on:input={updateDisplayed}
 		/>
+		{#if displayed && currentEvent}
+			<SubHeadline classes="dashboard-admin-event-event-subheadline"
+				>{currentEvent.title}</SubHeadline
+			>
+		{:else}
+			<TextLine>Kein aktuelles Event</TextLine>
+		{/if}
 	{:else}
-		<TextLine>No current Event</TextLine>
+		<TextLine>Keine Events</TextLine>
 	{/if}
 </SectionDashboard>
 
 <style>
 	:global(.dashboard-admin-event-section) {
 		max-width: 100rem;
+	}
+
+	:global(.dashboard-admin-event-event-subheadline) {
+		justify-self: center;
+		margin-top: var(--2x-margin);
 	}
 </style>

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -169,7 +169,7 @@
 			id={'dashboard-admin-event-drop-down'}
 			labelText="Aktuelles Event:"
 		/>
-		{#if displayed && currentEvent}
+		{#if currentEvent}
 			<SubHeadline classes="dashboard-admin-event-event-subheadline"
 				>{currentEvent.title}</SubHeadline
 			>

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -23,6 +23,7 @@
 	import UnsavedChangesCallbackWrapper from 'elements/navigation/unsavedChangesCallbackWrapper.svelte';
 	import ManualUnsavedChangesPopup from 'elements/navigation/manualUnsavedChangesPopup.svelte';
 	import type { boolean } from 'zod';
+	import { scrollToTop } from 'helper/scroll';
 
 	export let data: LoadDashboard & LoadAdminEvents;
 	let manualPopup: ManualUnsavedChangesPopup;
@@ -127,6 +128,8 @@
 				);
 			}
 		})(toSave);
+
+		scrollToTop();
 
 		message.setSaveMessage(saveType);
 		return isSaveType(saveType);

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -4,7 +4,7 @@
 
 	import { Clone } from 'helper/clone';
 	import { getAllEventTitle, getEventByTitle } from './eventsHelper';
-	import { unsavedChanges } from 'stores/saved';
+	import { unsavedChanges, setUnsavedChanges } from 'stores/saved';
 	import { onMount } from 'svelte';
 
 	import TextLine from 'elements/text/textLine.svelte';
@@ -12,6 +12,7 @@
 	import SectionDashboard from 'elements/section/sectionDashboard.svelte';
 	import DropDown from 'elements/input/dropDown.svelte';
 	import SubHeadline from 'elements/text/subHeadline.svelte';
+	import Input from 'elements/input/input.svelte';
 
 	export let data: LoadDashboard & LoadAdminEvents;
 	let copiedData = new Clone<LoadDashboard & LoadAdminEvents>(data);
@@ -24,15 +25,29 @@
 		updateDisplayed();
 	});
 
+	$: if (selected) {
+		// when selected changes this gets called
+		updateDisplayed();
+	}
+
 	function updateDisplayed(): void {
 		if (unsavedChanges()) {
 			console.log('unsaved changes');
+			resetSelected();
 			selected = displayed;
 			return;
 		}
 
 		displayed = selected;
 		currentEvent = getEventByTitle(copiedData.value.allEvents, displayed);
+	}
+
+	function resetSelected(): void {
+		selected = displayed;
+	}
+
+	async function trySaveAsync(): Promise<void> {
+		console.log('todo: save data');
 	}
 </script>
 
@@ -44,12 +59,23 @@
 			bind:selected
 			id={'dashboard-admin-event-drop-down'}
 			labelText="Aktuelles Event:"
-			on:input={updateDisplayed}
 		/>
 		{#if displayed && currentEvent}
 			<SubHeadline classes="dashboard-admin-event-event-subheadline"
 				>{currentEvent.title}</SubHeadline
 			>
+			<form class="dashboard-admin-event-form" on:submit|preventDefault={trySaveAsync}>
+				<Input
+					classes="dashboard-admin-event-title input"
+					id="dashboard-admin-event-title"
+					labelText="Titel:"
+					placeholderText="Titel"
+					ariaLabel="Gib den Titel des ausgewählten Events ein."
+					bind:value={currentEvent.title}
+					on:submit={trySaveAsync}
+					on:input={setUnsavedChanges}
+				/>
+			</form>
 		{:else}
 			<TextLine>Kein aktuelles Event</TextLine>
 		{/if}

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -13,6 +13,7 @@
 	import DropDown from 'elements/input/dropDown.svelte';
 	import SubHeadline from 'elements/text/subHeadline.svelte';
 	import Input from 'elements/input/input.svelte';
+	import TextArea from 'elements/input/textArea.svelte';
 
 	export let data: LoadDashboard & LoadAdminEvents;
 	let copiedData = new Clone<LoadDashboard & LoadAdminEvents>(data);
@@ -27,7 +28,9 @@
 
 	$: if (selected) {
 		// when selected changes this gets called
-		updateDisplayed();
+		if (displayed !== selected) {
+			updateDisplayed();
+		}
 	}
 
 	function updateDisplayed(): void {
@@ -72,6 +75,76 @@
 					placeholderText="Titel"
 					ariaLabel="Gib den Titel des ausgewählten Events ein."
 					bind:value={currentEvent.title}
+					on:submit={trySaveAsync}
+					on:input={setUnsavedChanges}
+				/>
+				<Input
+					classes="dashboard-admin-event-sub-title input"
+					id="dashboard-admin-event-sub-title"
+					labelText="Untertitel:"
+					placeholderText="Untertitel"
+					ariaLabel="Gib den Untertitel des ausgewählten Events ein."
+					bind:value={currentEvent.subtitle}
+					on:submit={trySaveAsync}
+					on:input={setUnsavedChanges}
+				/>
+				<Input
+					classes="dashboard-admin-event-description-headline input"
+					id="dashboard-admin-event-description-headline"
+					labelText="Überschrift Beschreibung:"
+					placeholderText="Überschrift Beschreibung:"
+					ariaLabel="Gib die Überschrift der Eventbeschreibung des ausgewählten Events ein."
+					bind:value={currentEvent.description_headline}
+					on:submit={trySaveAsync}
+					on:input={setUnsavedChanges}
+				/>
+				<TextArea
+					classes="dashboard-admin-event-description input"
+					id="dashboard-admin-event-description"
+					labelText="Beschreibung:"
+					placeholderText="Beschreibung"
+					ariaLabel="Gib den Eventbeschreibungstext des ausgewählten Events ein."
+					bind:value={currentEvent.description}
+					on:submit={trySaveAsync}
+					on:input={setUnsavedChanges}
+				/>
+				<Input
+					classes="dashboard-admin-event-twitch-url input"
+					id="dashboard-admin-event-twitch-url"
+					labelText="Twitch URL:"
+					placeholderText="Twitch URL:"
+					ariaLabel="Gib die URL der Twitchseite des ausgewählten Events ein."
+					bind:value={currentEvent.twitch_url}
+					on:submit={trySaveAsync}
+					on:input={setUnsavedChanges}
+				/>
+				<Input
+					classes="dashboard-admin-event-discord-url input"
+					id="dashboard-admin-event-discord-url"
+					labelText="Discord URL:"
+					placeholderText="Discord URL:"
+					ariaLabel="Gib die URL des Discordservers des ausgewählten Events ein."
+					bind:value={currentEvent.discord_url}
+					on:submit={trySaveAsync}
+					on:input={setUnsavedChanges}
+				/>
+				<Input
+					classes="dashboard-admin-event-presskit-url input"
+					id="dashboard-admin-event-presskit-url"
+					labelText="Presskit URL:"
+					placeholderText="Presskit URL:"
+					ariaLabel="Gib die URL des Presskits des ausgewählten Events ein."
+					bind:value={currentEvent.presskit_url}
+					on:submit={trySaveAsync}
+					on:input={setUnsavedChanges}
+				/>
+				<Input
+					classes="dashboard-admin-event-youtube-trailer-id input"
+					id="dashboard-admin-event-youtube-trailer-id"
+					labelText="YouTube Trailer ID:"
+					placeholderText="YouTube Trailer ID:"
+					ariaLabel="Gib die ID des YouTube Trailer des ausgewählten Events ein."
+					bind:value={currentEvent.trailer_youtube_id}
 					on:submit={trySaveAsync}
 					on:input={setUnsavedChanges}
 				/>

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -1,5 +1,36 @@
 <script lang="ts">
+	import type { LoadAdminEvents, LoadDashboard } from 'types/dashboardLoadTypes';
+
+	import { Clone } from 'helper/clone';
+	import { getDropDownKeys } from './eventsHelper';
+
 	import TextLine from 'elements/text/textLine.svelte';
+	import SaveMessage from 'elements/text/saveMessage.svelte';
+	import SectionDashboard from 'elements/section/sectionDashboard.svelte';
+	import DropDown from 'elements/input/dropDown.svelte';
+
+	export let data: LoadDashboard & LoadAdminEvents;
+	let copiedData = new Clone<LoadDashboard & LoadAdminEvents>(data);
+	let message: SaveMessage;
+	let selected: string;
 </script>
 
-<TextLine classes="text" --text-align="center">TODO: Hier kommt Ser Beste Test hin.</TextLine>
+<SectionDashboard classes="dashboard-admin-event-section">
+	<SaveMessage bind:this={message} />
+	{#if copiedData.value.allEvents}
+		<DropDown
+			data={getDropDownKeys(copiedData.value.allEvents)}
+			bind:selected
+			id={'dashboard-admin-event-drop-down'}
+			labelText="Aktuelles Event:"
+		/>
+	{:else}
+		<TextLine>No current Event</TextLine>
+	{/if}
+</SectionDashboard>
+
+<style>
+	:global(.dashboard-admin-event-section) {
+		max-width: 100rem;
+	}
+</style>

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -96,8 +96,8 @@
 				trailer_youtube_id: '',
 				description_headline: '',
 				description: '',
-				schedule_visible_from: formatDate(String(new Date()), '%YYYY-%MM-%DDT%hh:%mm'),
-				publish_date: formatDate(String(new Date()), '%YYYY-%MM-%DDT%hh:%mm')
+				schedule_visible_from: formatDate(String(new Date()), '%YYYY-%MM-%DDT%hh:00:00'),
+				publish_date: formatDate(String(new Date()), '%YYYY-%MM-%DDT%hh:00:00')
 			};
 			copiedData.value.allEvents.push(event);
 			selected = event.title;

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -11,6 +11,7 @@
 	import { unsavedChanges, setUnsavedChanges } from 'stores/saved';
 	import { convertTimeAndDateToHTML, convertTimeAndDateToSQL, formatDate } from 'helper/dates';
 	import { trySaveDashboardDataAsync } from 'helper/trySaveDashboardData';
+	import { scrollToTop } from 'helper/scroll';
 
 	import TextLine from 'elements/text/textLine.svelte';
 	import SaveMessage from 'elements/text/saveMessage.svelte';
@@ -22,8 +23,6 @@
 	import Button from 'elements/input/button.svelte';
 	import UnsavedChangesCallbackWrapper from 'elements/navigation/unsavedChangesCallbackWrapper.svelte';
 	import ManualUnsavedChangesPopup from 'elements/navigation/manualUnsavedChangesPopup.svelte';
-	import type { boolean } from 'zod';
-	import { scrollToTop } from 'helper/scroll';
 
 	export let data: LoadDashboard & LoadAdminEvents;
 	let manualPopup: ManualUnsavedChangesPopup;

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -113,66 +113,6 @@
 					on:submit={trySaveAsync}
 					on:input={setUnsavedChanges}
 				/>
-				<Input
-					classes="dashboard-admin-event-description-headline input"
-					id="dashboard-admin-event-description-headline"
-					labelText="Überschrift Beschreibung:"
-					placeholderText="Überschrift Beschreibung:"
-					ariaLabel="Gib die Überschrift der Eventbeschreibung des ausgewählten Events ein."
-					bind:value={currentEvent.description_headline}
-					on:submit={trySaveAsync}
-					on:input={setUnsavedChanges}
-				/>
-				<TextArea
-					classes="dashboard-admin-event-description input"
-					id="dashboard-admin-event-description"
-					labelText="Beschreibung:"
-					placeholderText="Beschreibung"
-					ariaLabel="Gib den Eventbeschreibungstext des ausgewählten Events ein."
-					bind:value={currentEvent.description}
-					on:submit={trySaveAsync}
-					on:input={setUnsavedChanges}
-				/>
-				<Input
-					classes="dashboard-admin-event-twitch-url input"
-					id="dashboard-admin-event-twitch-url"
-					labelText="Twitch URL:"
-					placeholderText="Twitch URL:"
-					ariaLabel="Gib die URL der Twitchseite des ausgewählten Events ein."
-					bind:value={currentEvent.twitch_url}
-					on:submit={trySaveAsync}
-					on:input={setUnsavedChanges}
-				/>
-				<Input
-					classes="dashboard-admin-event-discord-url input"
-					id="dashboard-admin-event-discord-url"
-					labelText="Discord URL:"
-					placeholderText="Discord URL:"
-					ariaLabel="Gib die URL des Discordservers des ausgewählten Events ein."
-					bind:value={currentEvent.discord_url}
-					on:submit={trySaveAsync}
-					on:input={setUnsavedChanges}
-				/>
-				<Input
-					classes="dashboard-admin-event-presskit-url input"
-					id="dashboard-admin-event-presskit-url"
-					labelText="Presskit URL:"
-					placeholderText="Presskit URL:"
-					ariaLabel="Gib die URL des Presskits des ausgewählten Events ein."
-					bind:value={currentEvent.presskit_url}
-					on:submit={trySaveAsync}
-					on:input={setUnsavedChanges}
-				/>
-				<Input
-					classes="dashboard-admin-event-youtube-trailer-id input"
-					id="dashboard-admin-event-youtube-trailer-id"
-					labelText="YouTube Trailer ID:"
-					placeholderText="YouTube Trailer ID:"
-					ariaLabel="Gib die ID des YouTube Trailer des ausgewählten Events ein."
-					bind:value={currentEvent.trailer_youtube_id}
-					on:submit={trySaveAsync}
-					on:input={setUnsavedChanges}
-				/>
 				<div class="dashboard-admin-event-time-date-wrapper">
 					<Input
 						classes="dashboard-admin-event-start-date input"
@@ -221,6 +161,66 @@
 						on:input={setUnsavedChanges}
 					/>
 				</div>
+				<Input
+					classes="dashboard-admin-event-twitch-url input"
+					id="dashboard-admin-event-twitch-url"
+					labelText="Twitch URL:"
+					placeholderText="Twitch URL:"
+					ariaLabel="Gib die URL der Twitchseite des ausgewählten Events ein."
+					bind:value={currentEvent.twitch_url}
+					on:submit={trySaveAsync}
+					on:input={setUnsavedChanges}
+				/>
+				<Input
+					classes="dashboard-admin-event-discord-url input"
+					id="dashboard-admin-event-discord-url"
+					labelText="Discord URL:"
+					placeholderText="Discord URL:"
+					ariaLabel="Gib die URL des Discordservers des ausgewählten Events ein."
+					bind:value={currentEvent.discord_url}
+					on:submit={trySaveAsync}
+					on:input={setUnsavedChanges}
+				/>
+				<Input
+					classes="dashboard-admin-event-presskit-url input"
+					id="dashboard-admin-event-presskit-url"
+					labelText="Presskit URL:"
+					placeholderText="Presskit URL:"
+					ariaLabel="Gib die URL des Presskits des ausgewählten Events ein."
+					bind:value={currentEvent.presskit_url}
+					on:submit={trySaveAsync}
+					on:input={setUnsavedChanges}
+				/>
+				<Input
+					classes="dashboard-admin-event-youtube-trailer-id input"
+					id="dashboard-admin-event-youtube-trailer-id"
+					labelText="YouTube Trailer ID:"
+					placeholderText="YouTube Trailer ID:"
+					ariaLabel="Gib die ID des YouTube Trailer des ausgewählten Events ein."
+					bind:value={currentEvent.trailer_youtube_id}
+					on:submit={trySaveAsync}
+					on:input={setUnsavedChanges}
+				/>
+				<Input
+					classes="dashboard-admin-event-description-headline input"
+					id="dashboard-admin-event-description-headline"
+					labelText="Überschrift Beschreibung:"
+					placeholderText="Überschrift Beschreibung:"
+					ariaLabel="Gib die Überschrift der Eventbeschreibung des ausgewählten Events ein."
+					bind:value={currentEvent.description_headline}
+					on:submit={trySaveAsync}
+					on:input={setUnsavedChanges}
+				/>
+				<TextArea
+					classes="dashboard-admin-event-description input"
+					id="dashboard-admin-event-description"
+					labelText="Beschreibung:"
+					placeholderText="Beschreibung"
+					ariaLabel="Gib den Eventbeschreibungstext des ausgewählten Events ein."
+					bind:value={currentEvent.description}
+					on:submit={trySaveAsync}
+					on:input={setUnsavedChanges}
+				/>
 
 				<Button
 					classes="button-text dashboard-admin-event-submit-button"

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
 	import type { LoadAdminEvents, LoadDashboard } from 'types/dashboardLoadTypes';
 	import type { DashboardEvent } from 'types/dashboardProvideTypes';
+	import type { TimeDate } from 'helper/dates';
 
+	import { onMount } from 'svelte';
 	import { Clone } from 'helper/clone';
 	import { getAllEventTitle, getEventByTitle } from './eventsHelper';
 	import { unsavedChanges, setUnsavedChanges } from 'stores/saved';
-	import { onMount } from 'svelte';
+	import { splitTimeAndDate } from 'helper/dates';
 
 	import TextLine from 'elements/text/textLine.svelte';
 	import SaveMessage from 'elements/text/saveMessage.svelte';
@@ -18,17 +20,20 @@
 
 	export let data: LoadDashboard & LoadAdminEvents;
 	let copiedData = new Clone<LoadDashboard & LoadAdminEvents>(data);
+
 	let message: SaveMessage;
 	let selected: string;
 	let displayed: string;
+
 	let currentEvent: DashboardEvent;
+	let currentPublishShaduleDate: TimeDate;
+	let currentPublishEventDate: TimeDate;
 
 	onMount(() => {
 		updateDisplayed();
 	});
 
 	$: if (selected) {
-		// when selected changes this gets called
 		if (displayed !== selected) {
 			updateDisplayed();
 		}
@@ -44,6 +49,8 @@
 
 		displayed = selected;
 		currentEvent = getEventByTitle(copiedData.value.allEvents, displayed);
+		currentPublishEventDate = splitTimeAndDate(currentEvent.publish_date);
+		currentPublishShaduleDate = splitTimeAndDate(currentEvent.schedule_visible_from);
 	}
 
 	function resetSelected(): void {
@@ -181,7 +188,7 @@
 						placeholderText="Veröffentlichungsdatum Event:"
 						type="date"
 						ariaLabel="Gib das Veröffentlichungsdatum des ausgewählten Events ein."
-						bind:value={currentEvent.publish_date}
+						bind:value={currentPublishEventDate.date}
 						on:submit={trySaveAsync}
 						on:input={setUnsavedChanges}
 					/>
@@ -192,7 +199,7 @@
 						placeholderText="Veröffentlichungsuhrzeit Event:"
 						type="time"
 						ariaLabel="Gib das Veröffentlichungsuhrzeit des ausgewählten Events ein."
-						bind:value={currentEvent.publish_date}
+						bind:value={currentPublishEventDate.time}
 						on:submit={trySaveAsync}
 						on:input={setUnsavedChanges}
 					/>
@@ -205,7 +212,7 @@
 						placeholderText="Veröffentlichungsuhrzeit Ablaufplan:"
 						type="date"
 						ariaLabel="Gib das Veröffentlichungsuhrzeit des Ablaufplanes des ausgewählten Events ein."
-						bind:value={currentEvent.schedule_visible_from}
+						bind:value={currentPublishShaduleDate.date}
 						on:submit={trySaveAsync}
 						on:input={setUnsavedChanges}
 					/>
@@ -216,7 +223,7 @@
 						placeholderText="Veröffentlichungsuhrzeit Event:"
 						type="time"
 						ariaLabel="Gib das Veröffentlichungsuhrzeit des ausgewählten Events ein."
-						bind:value={currentEvent.schedule_visible_from}
+						bind:value={currentPublishShaduleDate.time}
 						on:submit={trySaveAsync}
 						on:input={setUnsavedChanges}
 					/>

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -122,11 +122,17 @@
 
 		const saveType: SaveMessageType = await (async (toSave: SetAdminEvent) => {
 			if (toSave.id === 0) {
-				return await trySaveDashboardDataAsync<SetAdminEvent>(
+				const saveType = await trySaveDashboardDataAsync<SetAdminEvent>(
 					toSave,
 					`/api/dashboard/admin/event/new`,
 					'POST'
 				);
+
+				if (isSaveType(saveType)) {
+					location.reload(); // reload page to fetch new data from database
+				}
+
+				return saveType;
 			} else {
 				return await trySaveDashboardDataAsync<SetAdminEvent>(
 					toSave,

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -81,9 +81,9 @@
 
 		validateData(toSave);
 
-		const saveType: SaveMessageType = await trySaveDashboardDataAsync<DashboardEvent>(
-			currentEvent,
-			`/api/dashboard/admin/event/${currentEvent.id}`
+		const saveType: SaveMessageType = await trySaveDashboardDataAsync<SetAdminEvent>(
+			toSave,
+			`/api/dashboard/admin/event/${toSave.id}`
 		);
 
 		message.setSaveMessage(saveType);

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -77,8 +77,6 @@
 		toSave.start_date = toSave.start_date;
 		toSave.end_date = toSave.end_date;
 
-		console.log(toSave);
-
 		validateData(toSave);
 
 		const saveType: SaveMessageType = await trySaveDashboardDataAsync<SetAdminEvent>(

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -21,8 +21,11 @@
 	import TextArea from 'elements/input/textArea.svelte';
 	import Button from 'elements/input/button.svelte';
 	import UnsavedChangesCallbackWrapper from 'elements/navigation/unsavedChangesCallbackWrapper.svelte';
+	import ManualUnsavedChangesPopup from 'elements/navigation/manualUnsavedChangesPopup.svelte';
 
 	export let data: LoadDashboard & LoadAdminEvents;
+	let manualPopup: ManualUnsavedChangesPopup;
+
 	let copiedData = new Clone<LoadDashboard & LoadAdminEvents>(data);
 
 	let message: SaveMessage;
@@ -30,6 +33,14 @@
 	let displayed: string;
 
 	let currentEvent: DashboardEvent;
+
+	function navigate(): void {
+		updateDisplayed();
+	}
+	function stay(): void {
+		resetSelected();
+		selected = displayed;
+	}
 
 	onMount(() => {
 		updateDisplayed();
@@ -43,9 +54,7 @@
 
 	function updateDisplayed(): void {
 		if (unsavedChanges()) {
-			console.log('unsaved changes');
-			resetSelected();
-			selected = displayed;
+			manualPopup.show();
 			return;
 		}
 
@@ -83,6 +92,11 @@
 </script>
 
 <UnsavedChangesCallbackWrapper callback={trySaveAsync} />
+<ManualUnsavedChangesPopup
+	bind:this={manualPopup}
+	navigateCallback={navigate}
+	stayCallback={stay}
+/>
 <SectionDashboard classes="dashboard-admin-event-section">
 	<SaveMessage bind:this={message} />
 	{#if copiedData.value.allEvents}

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -86,7 +86,7 @@
 		if (!contains) {
 			const event: DashboardEvent = {
 				id: 0,
-				title: 'New Event',
+				title: '',
 				subtitle: '',
 				start_date: formatDate(String(new Date()), '%YYYY-%MM-%DD'),
 				end_date: formatDate(String(new Date()), '%YYYY-%MM-%DD'),

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -149,6 +149,78 @@
 					on:submit={trySaveAsync}
 					on:input={setUnsavedChanges}
 				/>
+				<div class="dashboard-admin-event-time-date-wrapper">
+					<Input
+						classes="dashboard-admin-event-start-date input"
+						id="dashboard-admin-event-start-date"
+						labelText="Start Datum:"
+						placeholderText="Start Datum:"
+						type="date"
+						ariaLabel="Gib das Start Datum des ausgewählten Events ein."
+						bind:value={currentEvent.start_date}
+						on:submit={trySaveAsync}
+						on:input={setUnsavedChanges}
+					/>
+					<Input
+						classes="dashboard-admin-event-end-date input"
+						id="dashboard-admin-event-end-date"
+						labelText="End Datum:"
+						placeholderText="End Datum:"
+						type="date"
+						ariaLabel="Gib das End Datum des ausgewählten Events ein."
+						bind:value={currentEvent.end_date}
+						on:submit={trySaveAsync}
+						on:input={setUnsavedChanges}
+					/>
+				</div>
+				<div class="dashboard-admin-event-time-date-wrapper">
+					<Input
+						classes="dashboard-admin-event-publish-event-date input"
+						id="dashboard-admin-event-publish-event-date"
+						labelText="Veröffentlichungsdatum Event:"
+						placeholderText="Veröffentlichungsdatum Event:"
+						type="date"
+						ariaLabel="Gib das Veröffentlichungsdatum des ausgewählten Events ein."
+						bind:value={currentEvent.publish_date}
+						on:submit={trySaveAsync}
+						on:input={setUnsavedChanges}
+					/>
+					<Input
+						classes="dashboard-admin-event-publish-event-time input"
+						id="dashboard-admin-event-publish-event-time"
+						labelText="Veröffentlichungsuhrzeit Event:"
+						placeholderText="Veröffentlichungsuhrzeit Event:"
+						type="time"
+						ariaLabel="Gib das Veröffentlichungsuhrzeit des ausgewählten Events ein."
+						bind:value={currentEvent.publish_date}
+						on:submit={trySaveAsync}
+						on:input={setUnsavedChanges}
+					/>
+				</div>
+				<div class="dashboard-admin-event-time-date-wrapper">
+					<Input
+						classes="dashboard-admin-event-publish-shedule-date input"
+						id="dashboard-admin-event-publish-shedule-date"
+						labelText="Veröffentlichungsuhrzeit Ablaufplan:"
+						placeholderText="Veröffentlichungsuhrzeit Ablaufplan:"
+						type="date"
+						ariaLabel="Gib das Veröffentlichungsuhrzeit des Ablaufplanes des ausgewählten Events ein."
+						bind:value={currentEvent.schedule_visible_from}
+						on:submit={trySaveAsync}
+						on:input={setUnsavedChanges}
+					/>
+					<Input
+						classes="dashboard-admin-event-publish-shedule-time input"
+						id="dashboard-admin-event-publish-shedule-time"
+						labelText="Veröffentlichungsuhrzeit Event:"
+						placeholderText="Veröffentlichungsuhrzeit Event:"
+						type="time"
+						ariaLabel="Gib das Veröffentlichungsuhrzeit des ausgewählten Events ein."
+						bind:value={currentEvent.schedule_visible_from}
+						on:submit={trySaveAsync}
+						on:input={setUnsavedChanges}
+					/>
+				</div>
 
 				<Button
 					classes="button-text dashboard-admin-event-submit-button"
@@ -173,6 +245,23 @@
 
 	:global(.dashboard-admin-event-event-subheadline) {
 		justify-self: center;
+		margin-top: var(--4x-margin);
+	}
+
+	.dashboard-admin-event-form {
+		display: flex;
+		flex-direction: column;
+		gap: var(--full-gap);
+	}
+
+	.dashboard-admin-event-time-date-wrapper {
+		display: flex;
+		flex-direction: row;
+		gap: var(--full-gap);
+	}
+
+	:global(.dashboard-admin-event-submit-button) {
 		margin-top: var(--2x-margin);
+		align-self: center;
 	}
 </style>

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -23,6 +23,7 @@
 	import Button from 'elements/input/button.svelte';
 	import UnsavedChangesCallbackWrapper from 'elements/navigation/unsavedChangesCallbackWrapper.svelte';
 	import ManualUnsavedChangesPopup from 'elements/navigation/manualUnsavedChangesPopup.svelte';
+	import Message from 'elements/text/message.svelte';
 
 	export let data: LoadDashboard & LoadAdminEvents;
 	let manualPopup: ManualUnsavedChangesPopup;
@@ -34,6 +35,7 @@
 	let displayed: string;
 
 	let currentEvent: DashboardEvent;
+	let errorQue: string[] = ['test1', 'test2', 'test3'];
 
 	function navigate(): void {
 		updateDisplayed();
@@ -111,7 +113,12 @@
 		toSave.start_date = toSave.start_date;
 		toSave.end_date = toSave.end_date;
 
-		validateData(toSave, copiedData.value.allEvents);
+		scrollToTop(); // scroll here already so that all error messages can be seen.
+
+		errorQue = validateData(toSave, copiedData.value.allEvents);
+		if (errorQue.length > 0) {
+			return false;
+		}
 
 		const saveType: SaveMessageType = await (async (toSave: SetAdminEvent) => {
 			if (toSave.id === 0) {
@@ -127,8 +134,6 @@
 				);
 			}
 		})(toSave);
-
-		scrollToTop();
 
 		message.setSaveMessage(saveType);
 		return isSaveType(saveType);
@@ -149,7 +154,12 @@
 	>
 		Neues Event
 	</Button>
-	<SaveMessage bind:this={message} />
+	<div class="dashboard-admin-event-message-wrapper">
+		<SaveMessage bind:this={message} />
+		{#each errorQue as error}
+			<Message message={error} />
+		{/each}
+	</div>
 	{#if copiedData.value.allEvents}
 		<DropDown
 			data={getAllEventTitle(copiedData.value.allEvents)}
@@ -312,6 +322,12 @@
 		max-width: 100rem;
 		display: flex;
 		flex-direction: column;
+	}
+
+	.dashboard-admin-event-message-wrapper {
+		display: flex;
+		flex-direction: column;
+		margin: var(--2x-margin) 0;
 	}
 
 	:global(.dashboard-admin-event-new-event-button) {

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -40,7 +40,7 @@
 	let displayed: string;
 
 	let currentEvent: DashboardEvent;
-	let errorQue: string[] = [];
+	let errorQueue: string[] = [];
 
 	function navigate(): void {
 		updateDisplayed();
@@ -122,8 +122,8 @@
 
 		scrollToTop(); // scroll here already so that all error messages can be seen.
 
-		errorQue = validateData(toSave, copiedData.value.allEvents);
-		if (errorQue.length > 0) {
+		errorQueue = validateData(toSave, copiedData.value.allEvents);
+		if (errorQueue.length > 0) {
 			return false;
 		}
 
@@ -169,7 +169,7 @@
 	</Button>
 	<div class="dashboard-admin-event-message-wrapper">
 		<SaveMessage bind:this={message} />
-		{#each errorQue as error}
+		{#each errorQueue as error}
 			<Message message={error} />
 		{/each}
 	</div>

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -9,7 +9,12 @@
 	import { isSaveType } from 'types/saveMessageType';
 	import { getAllEventTitle, getEventByTitle, validateData } from './eventsHelper';
 	import { unsavedChanges, setUnsavedChanges } from 'stores/saved';
-	import { convertTimeAndDateToHTML, convertTimeAndDateToSQL, formatDate } from 'helper/dates';
+	import {
+		checkSQLTimeAndDate,
+		convertTimeAndDateToHTML,
+		convertTimeAndDateToSQL,
+		formatDate
+	} from 'helper/dates';
 	import { trySaveDashboardDataAsync } from 'helper/trySaveDashboardData';
 	import { scrollToTop } from 'helper/scroll';
 
@@ -108,8 +113,10 @@
 
 	async function trySaveAsync(): Promise<boolean> {
 		const toSave: SetAdminEvent = structuredClone(currentEvent);
-		toSave.publish_date = convertTimeAndDateToSQL(toSave.publish_date);
-		toSave.schedule_visible_from = convertTimeAndDateToSQL(toSave.schedule_visible_from);
+		toSave.publish_date = checkSQLTimeAndDate(convertTimeAndDateToSQL(toSave.publish_date));
+		toSave.schedule_visible_from = checkSQLTimeAndDate(
+			convertTimeAndDateToSQL(toSave.schedule_visible_from)
+		);
 		toSave.start_date = toSave.start_date;
 		toSave.end_date = toSave.end_date;
 

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -40,7 +40,7 @@
 	let displayed: string;
 
 	let currentEvent: DashboardEvent;
-	let errorQue: string[] = ['test1', 'test2', 'test3'];
+	let errorQue: string[] = [];
 
 	function navigate(): void {
 		updateDisplayed();

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -162,7 +162,7 @@
 <SectionDashboard classes="dashboard-admin-event-section">
 	<Button
 		classes="button-text dashboard-admin-event-new-event-button"
-		ariaLabel="Klicke hier um ein neues Event anzulegen."
+		ariaLabel="Klicke hier, um ein neues Event anzulegen."
 		on:click={newEvent}
 	>
 		Neues Event

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 	import type { LoadAdminEvents, LoadDashboard } from 'types/dashboardLoadTypes';
 	import type { DashboardEvent } from 'types/dashboardProvideTypes';
+	import type { SetAdminEvent } from 'types/dashboardSetTypes';
 	import type { SaveMessageType } from 'types/saveMessageType';
 
 	import { onMount } from 'svelte';
 	import { Clone } from 'helper/clone';
+	import { isSaveType } from 'types/saveMessageType';
 	import { getAllEventTitle, getEventByTitle, validateData } from './eventsHelper';
 	import { unsavedChanges, setUnsavedChanges } from 'stores/saved';
 	import { convertTimeAndDateToHTML, convertTimeAndDateToSQL } from 'helper/dates';
@@ -18,7 +20,7 @@
 	import Input from 'elements/input/input.svelte';
 	import TextArea from 'elements/input/textArea.svelte';
 	import Button from 'elements/input/button.svelte';
-	import type { SetAdminEvent } from 'types/dashboardSetTypes';
+	import UnsavedChangesCallbackWrapper from 'elements/navigation/unsavedChangesCallbackWrapper.svelte';
 
 	export let data: LoadDashboard & LoadAdminEvents;
 	let copiedData = new Clone<LoadDashboard & LoadAdminEvents>(data);
@@ -59,7 +61,7 @@
 		selected = displayed;
 	}
 
-	async function trySaveAsync(): Promise<void> {
+	async function trySaveAsync(): Promise<boolean> {
 		const toSave: SetAdminEvent = structuredClone(currentEvent);
 		toSave.publish_date = convertTimeAndDateToSQL(toSave.publish_date);
 		toSave.schedule_visible_from = convertTimeAndDateToSQL(toSave.schedule_visible_from);
@@ -76,9 +78,11 @@
 		);
 
 		message.setSaveMessage(saveType);
+		return isSaveType(saveType);
 	}
 </script>
 
+<UnsavedChangesCallbackWrapper callback={trySaveAsync} />
 <SectionDashboard classes="dashboard-admin-event-section">
 	<SaveMessage bind:this={message} />
 	{#if copiedData.value.allEvents}

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -14,6 +14,7 @@
 	import SubHeadline from 'elements/text/subHeadline.svelte';
 	import Input from 'elements/input/input.svelte';
 	import TextArea from 'elements/input/textArea.svelte';
+	import Button from 'elements/input/button.svelte';
 
 	export let data: LoadDashboard & LoadAdminEvents;
 	let copiedData = new Clone<LoadDashboard & LoadAdminEvents>(data);
@@ -148,6 +149,14 @@
 					on:submit={trySaveAsync}
 					on:input={setUnsavedChanges}
 				/>
+
+				<Button
+					classes="button-text dashboard-admin-event-submit-button"
+					type={'submit'}
+					ariaLabel="Klicke zum Speichern"
+				>
+					Speichern
+				</Button>
 			</form>
 		{:else}
 			<TextLine>Kein aktuelles Event</TextLine>

--- a/src/routes/dashboard/admin/events/+page.ts
+++ b/src/routes/dashboard/admin/events/+page.ts
@@ -1,0 +1,21 @@
+import type { LoadAdminEvents } from "types/dashboardLoadTypes";
+import type { DashboardAllEvents } from "types/dashboardProvideTypes";
+
+import { apiUrl } from "helper/links";
+import { checkAndParseInputDataAsync } from "helper/parseJson";
+import { dashboardAllEventsScheme } from "types/dashboardProvideTypes";
+
+export async function load({ fetch }: { fetch: typeof globalThis.fetch }): Promise<LoadAdminEvents> {
+    const allEventsPromise = fetch(apiUrl("/api/dashboard/admin/all-events"));
+
+    const allEvents = await checkAndParseInputDataAsync<DashboardAllEvents>(
+        await allEventsPromise,
+        dashboardAllEventsScheme,
+        `Serveranfrage für alle Events nicht erfolgreich. throw error(404)`,
+        `Unerwartete Daten für alle Events. throw error(404)`
+    )
+
+    return {
+        allEvents,
+    }
+}

--- a/src/routes/dashboard/admin/events/+page.ts
+++ b/src/routes/dashboard/admin/events/+page.ts
@@ -11,8 +11,8 @@ export async function load({ fetch }: { fetch: typeof globalThis.fetch }): Promi
     const allEvents = await checkAndParseInputDataAsync<DashboardAllEvents>(
         await allEventsPromise,
         dashboardAllEventsScheme,
-        `Serveranfrage für alle Events nicht erfolgreich. throw error(404)`,
-        `Unerwartete Daten für alle Events. throw error(404)`
+        `Serveranfrage für alle Events nicht erfolgreich. throw error(406)`,
+        `Unerwartete Daten für alle Events. throw error(406)`
     )
 
     return {

--- a/src/routes/dashboard/admin/events/eventsHelper.ts
+++ b/src/routes/dashboard/admin/events/eventsHelper.ts
@@ -27,51 +27,51 @@ export function getEventByTitle(events: DashboardAllEvents, title: string): Dash
 
 
 export function validateData(data: SetAdminEvent, allEvents: DashboardAllEvents): string[] {
-    const errorQue: string[] = [];
+    const errorQueue: string[] = [];
 
     // name
     for (var event of allEvents) {
         if (event.id == data.id) { continue; }
         if (event.title.trim() === data.title.trim()) {
-            errorQue.push(`Event mit dem Titel ${data.title} existiert bereits.`)
+            errorQueue.push(`Event mit dem Titel ${data.title} existiert bereits.`)
         }
     }
 
     // text
     if (data.title.trim().length === 0) {
-        errorQue.push('Das Feld "Titel" muss angegeben werden.');
+        errorQueue.push('Das Feld "Titel" muss angegeben werden.');
     }
     if (data.subtitle.trim().length === 0) {
-        errorQue.push('Das Feld "Untertitel" muss angegeben werden.');
+        errorQueue.push('Das Feld "Untertitel" muss angegeben werden.');
     }
     if (data.description_headline.trim().length === 0) {
-        errorQue.push('Das Feld "Überschrift Beschreibung" muss angegeben werden.');
+        errorQueue.push('Das Feld "Überschrift Beschreibung" muss angegeben werden.');
     }
     if (data.description.trim().length === 0) {
-        errorQue.push('Das Feld "Beschreibung" muss angegeben werden.');
+        errorQueue.push('Das Feld "Beschreibung" muss angegeben werden.');
     }
 
     // dates
     if (!isBeforeOrSameDatesString(data.start_date, data.end_date)) {
-        errorQue.push('Das Start-Datum liegt nach dem End-Datum.');
+        errorQueue.push('Das Start-Datum liegt nach dem End-Datum.');
     }
     if (data.publish_date && data.schedule_visible_from) {
         if (!isBeforeOrSameDatesString(data.publish_date, data.schedule_visible_from)) {
-            errorQue.push('Der Ablaufplan ist vor dem Event sichtbar.');
+            errorQueue.push('Der Ablaufplan ist vor dem Event sichtbar.');
         }
     }
 
     // url
     const urlScheme = z.string().url().nullable();
     if (!urlScheme.safeParse(data.discord_url).success) {
-        errorQue.push('Das Discord URL ist nicht valide.');
+        errorQueue.push('Das Discord URL ist nicht valide.');
     }
     if (!urlScheme.safeParse(data.presskit_url).success) {
-        errorQue.push('Das Presskit URL ist nicht valide.');
+        errorQueue.push('Das Presskit URL ist nicht valide.');
     }
     if (!urlScheme.safeParse(data.twitch_url).success) {
-        errorQue.push('Das Twitch URL ist nicht valide.');
+        errorQueue.push('Das Twitch URL ist nicht valide.');
     }
 
-    return errorQue;
+    return errorQueue;
 }

--- a/src/routes/dashboard/admin/events/eventsHelper.ts
+++ b/src/routes/dashboard/admin/events/eventsHelper.ts
@@ -25,6 +25,14 @@ export function getEventByTitle(events: DashboardAllEvents, title: string): Dash
 
 
 export function validateData(data: SetAdminEvent, allEvents: DashboardAllEvents): string[] {
-    console.error("validation not implemented");
-    return [];
+    const errorQue: string[] = [];
+    for (var event of allEvents) {
+
+        if (event.id == data.id) { continue; }
+
+        if (event.title.trim() === data.title.trim()) {
+            errorQue.push(`Event mit dem Titel ${data.title} existiert bereits.`)
+        }
+    }
+    return errorQue;
 }

--- a/src/routes/dashboard/admin/events/eventsHelper.ts
+++ b/src/routes/dashboard/admin/events/eventsHelper.ts
@@ -24,7 +24,7 @@ export function getEventByTitle(events: DashboardAllEvents, title: string): Dash
 
 
 
-export function validateData(data: SetAdminEvent): string[] {
+export function validateData(data: SetAdminEvent, allEvents: DashboardAllEvents): string[] {
     console.error("validation not implemented");
     return [];
 }

--- a/src/routes/dashboard/admin/events/eventsHelper.ts
+++ b/src/routes/dashboard/admin/events/eventsHelper.ts
@@ -1,6 +1,7 @@
 import type { DashboardAllEvents, DashboardEvent } from "types/dashboardProvideTypes";
 
 import { error } from "@sveltejs/kit";
+import type { SetAdminEvent } from "types/dashboardSetTypes";
 
 export function getAllEventTitle(events: DashboardAllEvents): string[] {
     const title: string[] = [];
@@ -19,4 +20,11 @@ export function getEventByTitle(events: DashboardAllEvents, title: string): Dash
 
     console.error(`error while looking up event by title: ${title}`);
     throw error(500);
+}
+
+
+
+export function validateData(data: SetAdminEvent): string[] {
+    console.error("validation not implemented");
+    return [];
 }

--- a/src/routes/dashboard/admin/events/eventsHelper.ts
+++ b/src/routes/dashboard/admin/events/eventsHelper.ts
@@ -1,0 +1,9 @@
+import type { DashboardAllEvents } from "types/dashboardProvideTypes";
+
+export function getDropDownKeys(events: DashboardAllEvents): string[] {
+    const keys: string[] = [];
+    for (var event of events) {
+        keys.push(event.title);
+    }
+    return keys;
+}

--- a/src/routes/dashboard/admin/events/eventsHelper.ts
+++ b/src/routes/dashboard/admin/events/eventsHelper.ts
@@ -1,9 +1,22 @@
-import type { DashboardAllEvents } from "types/dashboardProvideTypes";
+import type { DashboardAllEvents, DashboardEvent } from "types/dashboardProvideTypes";
 
-export function getDropDownKeys(events: DashboardAllEvents): string[] {
-    const keys: string[] = [];
+import { error } from "@sveltejs/kit";
+
+export function getAllEventTitle(events: DashboardAllEvents): string[] {
+    const title: string[] = [];
     for (var event of events) {
-        keys.push(event.title);
+        title.push(event.title);
     }
-    return keys;
+    return title;
+}
+
+export function getEventByTitle(events: DashboardAllEvents, title: string): DashboardEvent {
+    for (var event of events) {
+        if (event.title === title) {
+            return event;
+        }
+    }
+
+    console.error(`error while looking up event by title: ${title}`);
+    throw error(500);
 }

--- a/src/routes/dashboard/admin/events/eventsHelper.ts
+++ b/src/routes/dashboard/admin/events/eventsHelper.ts
@@ -2,6 +2,8 @@ import type { DashboardAllEvents, DashboardEvent } from "types/dashboardProvideT
 
 import { error } from "@sveltejs/kit";
 import type { SetAdminEvent } from "types/dashboardSetTypes";
+import { isBeforeOrSameDatesString } from "helper/dates";
+import { z } from "zod";
 
 export function getAllEventTitle(events: DashboardAllEvents): string[] {
     const title: string[] = [];
@@ -26,13 +28,50 @@ export function getEventByTitle(events: DashboardAllEvents, title: string): Dash
 
 export function validateData(data: SetAdminEvent, allEvents: DashboardAllEvents): string[] {
     const errorQue: string[] = [];
+
+    // name
     for (var event of allEvents) {
-
         if (event.id == data.id) { continue; }
-
         if (event.title.trim() === data.title.trim()) {
             errorQue.push(`Event mit dem Titel ${data.title} existiert bereits.`)
         }
     }
+
+    // text
+    if (data.title.trim().length === 0) {
+        errorQue.push('Das Feld "Titel" muss angegeben werden.');
+    }
+    if (data.subtitle.trim().length === 0) {
+        errorQue.push('Das Feld "Untertitel" muss angegeben werden.');
+    }
+    if (data.description_headline.trim().length === 0) {
+        errorQue.push('Das Feld "Überschrift Beschreibung" muss angegeben werden.');
+    }
+    if (data.description.trim().length === 0) {
+        errorQue.push('Das Feld "Beschreibung" muss angegeben werden.');
+    }
+
+    // dates
+    if (!isBeforeOrSameDatesString(data.start_date, data.end_date)) {
+        errorQue.push('Das Start-Datum liegt nach dem End-Datum.');
+    }
+    if (data.publish_date && data.schedule_visible_from) {
+        if (!isBeforeOrSameDatesString(data.publish_date, data.schedule_visible_from)) {
+            errorQue.push('Der Ablaufplan ist vor dem Event sichtbar.');
+        }
+    }
+
+    // url
+    const urlScheme = z.string().url().nullable();
+    if (!urlScheme.safeParse(data.discord_url).success) {
+        errorQue.push('Das Discord URL ist nicht valide.');
+    }
+    if (!urlScheme.safeParse(data.presskit_url).success) {
+        errorQue.push('Das Presskit URL ist nicht valide.');
+    }
+    if (!urlScheme.safeParse(data.twitch_url).success) {
+        errorQue.push('Das Twitch URL ist nicht valide.');
+    }
+
     return errorQue;
 }

--- a/src/routes/dashboard/admin/events/eventsHelper.ts
+++ b/src/routes/dashboard/admin/events/eventsHelper.ts
@@ -2,8 +2,8 @@ import type { DashboardAllEvents, DashboardEvent } from "types/dashboardProvideT
 
 import { error } from "@sveltejs/kit";
 import type { SetAdminEvent } from "types/dashboardSetTypes";
-import { isBeforeOrSameDatesString } from "helper/dates";
-import { z } from "zod";
+import { checkSQLTimeAndDate, convertTimeAndDateToSQL, isBeforeOrSameDatesString } from "helper/dates";
+import { Schema, z } from "zod";
 
 export function getAllEventTitle(events: DashboardAllEvents): string[] {
     const title: string[] = [];
@@ -24,7 +24,33 @@ export function getEventByTitle(events: DashboardAllEvents, title: string): Dash
     throw error(500);
 }
 
+export function convertSaveData(data: SetAdminEvent): SetAdminEvent {
+    const trimOrNull: Function = (entry: string): string | null => {
+        if (entry.trim().length === 0) {
+            return null;
+        }
+        return entry.trim();
+    }
+    const trim: Function = (entry: string): string => {
+        return entry.trim();
+    }
 
+    return {
+        id: data.id,
+        title: trim(data.title),
+        subtitle: trim(data.title),
+        start_date: data.start_date,
+        end_date: data.end_date,
+        discord_url: trimOrNull(data.discord_url),
+        twitch_url: trimOrNull(data.twitch_url),
+        presskit_url: trimOrNull(data.presskit_url),
+        trailer_youtube_id: trimOrNull(data.trailer_youtube_id),
+        description_headline: trim(data.description_headline),
+        description: trim(data.description),
+        schedule_visible_from: checkSQLTimeAndDate(convertTimeAndDateToSQL(data.schedule_visible_from)),
+        publish_date: checkSQLTimeAndDate(convertTimeAndDateToSQL(data.publish_date)),
+    }
+}
 
 export function validateData(data: SetAdminEvent, allEvents: DashboardAllEvents): string[] {
     const errorQueue: string[] = [];
@@ -64,13 +90,13 @@ export function validateData(data: SetAdminEvent, allEvents: DashboardAllEvents)
     // url
     const urlScheme = z.string().url().nullable();
     if (!urlScheme.safeParse(data.discord_url).success) {
-        errorQueue.push('Das Discord URL ist nicht valide.');
+        errorQueue.push('Die Discord-URL ist nicht valide.');
     }
     if (!urlScheme.safeParse(data.presskit_url).success) {
-        errorQueue.push('Das Presskit URL ist nicht valide.');
+        errorQueue.push('Die Presskit-URL ist nicht valide.');
     }
     if (!urlScheme.safeParse(data.twitch_url).success) {
-        errorQueue.push('Das Twitch URL ist nicht valide.');
+        errorQueue.push('Die Twitch-URL ist nicht valide.');
     }
 
     return errorQueue;

--- a/src/routes/dashboard/admin/globals/+page.svelte
+++ b/src/routes/dashboard/admin/globals/+page.svelte
@@ -13,10 +13,11 @@
 	import { trySaveDashboardDataAsync } from 'helper/trySaveDashboardData';
 
 	export let data: LoadDashboard; // data from database
+
 	let copiedData = new Clone<LoadDashboard>(data); // copied data from database to not save original data until save
 	let message: SaveMessage;
 
-	async function trySaveAsync(): Promise<void> {
+	async function trySaveAsync(): Promise<boolean> {
 		const adminGlobals: SetAdminGlobals = {
 			footer_text: copiedData.value.globals.footer_text
 		};
@@ -27,6 +28,7 @@
 		);
 
 		message.setSaveMessage(saveType);
+		return isSaveType(saveType);
 	}
 </script>
 

--- a/src/routes/dashboard/admin/globals/+page.svelte
+++ b/src/routes/dashboard/admin/globals/+page.svelte
@@ -11,11 +11,9 @@
 
 	import { setUnsavedChanges } from 'stores/saved';
 	import { trySaveDashboardDataAsync } from 'helper/trySaveDashboardData';
-	import UnsavedChangesPopup from 'elements/navigation/unsavedChangesPopup.svelte';
 	import UnsavedChangesCallbackWrapper from 'elements/navigation/unsavedChangesCallbackWrapper.svelte';
 
 	export let data: LoadDashboard; // data from database
-	export let unsavedChangesPopup: UnsavedChangesPopup;
 
 	let copiedData = new Clone<LoadDashboard>(data); // copied data from database to not save original data until save
 	let message: SaveMessage;
@@ -35,7 +33,7 @@
 	}
 </script>
 
-<UnsavedChangesCallbackWrapper component={unsavedChangesPopup} callback={trySaveAsync} />
+<UnsavedChangesCallbackWrapper callback={trySaveAsync} />
 <SectionDashboard classes="dashboard-admin-global-section">
 	<SaveMessage bind:this={message} />
 	<form class="dashboard-admin-global-form" on:submit|preventDefault={trySaveAsync}>

--- a/src/routes/dashboard/admin/globals/+page.svelte
+++ b/src/routes/dashboard/admin/globals/+page.svelte
@@ -27,9 +27,6 @@
 		);
 
 		message.setSaveMessage(saveType);
-		if (isSaveType(saveType)) {
-			data = copiedData.get();
-		}
 	}
 </script>
 

--- a/src/routes/dashboard/admin/globals/+page.svelte
+++ b/src/routes/dashboard/admin/globals/+page.svelte
@@ -11,8 +11,11 @@
 
 	import { setUnsavedChanges } from 'stores/saved';
 	import { trySaveDashboardDataAsync } from 'helper/trySaveDashboardData';
+	import UnsavedChangesPopup from 'elements/navigation/unsavedChangesPopup.svelte';
+	import UnsavedChangesCallbackWrapper from 'elements/navigation/unsavedChangesCallbackWrapper.svelte';
 
 	export let data: LoadDashboard; // data from database
+	export let unsavedChangesPopup: UnsavedChangesPopup;
 
 	let copiedData = new Clone<LoadDashboard>(data); // copied data from database to not save original data until save
 	let message: SaveMessage;
@@ -32,6 +35,7 @@
 	}
 </script>
 
+<UnsavedChangesCallbackWrapper component={unsavedChangesPopup} callback={trySaveAsync} />
 <SectionDashboard classes="dashboard-admin-global-section">
 	<SaveMessage bind:this={message} />
 	<form class="dashboard-admin-global-form" on:submit|preventDefault={trySaveAsync}>

--- a/src/routes/year/[year]/year.ts
+++ b/src/routes/year/[year]/year.ts
@@ -23,8 +23,8 @@ export async function loadYearAsync(fetch: Function, year: number | undefined = 
     const yearData: Year = await checkAndParseInputDataAsync<Year>(
         await yearDataPromise,
         yearScheme,
-        `Serveranfrage für das Jahr ${year} nicht erfolgreich. throw error(404)`,
-        `Unerwartete Daten für das Jahr ${year}. throw error(404)`
+        `Serveranfrage für das Jahr ${year} nicht erfolgreich. throw error(406)`,
+        `Unerwartete Daten für das Jahr ${year}. throw error(406)`
     );
     const globalsData: Globals = await checkAndParseGlobalsAsync(await globalsPromise);
 

--- a/src/stores/saveCallback.ts
+++ b/src/stores/saveCallback.ts
@@ -1,0 +1,15 @@
+import { writable, get, type Writable } from "svelte/store";
+type ValueType = (() => Promise<boolean>) | undefined;
+const _callback: Writable<ValueType> = writable(undefined);
+
+export function saveCallback(): ValueType {
+    return get(_callback);
+}
+
+export function resetSaveCallback(): void {
+    _callback.set(undefined);
+}
+
+export function setSaveCallback(callback: () => Promise<boolean>): void {
+    _callback.set(callback);
+}

--- a/src/types/dashboardLoadTypes.ts
+++ b/src/types/dashboardLoadTypes.ts
@@ -1,6 +1,6 @@
 import type { Globals } from "./provideTypes";
-import type { DashboardRoles, AdminAllEvents, AdminEvent } from "./dashboardProvideTypes";
+import type { DashboardRoles, DashboardAllEvents } from "./dashboardProvideTypes";
 
 export type LoadDashboard = { roles: DashboardRoles, globals: Globals }
 
-export type LoadAdminEvents = { allEvents: AdminAllEvents, event: AdminEvent };
+export type LoadAdminEvents = { allEvents: DashboardAllEvents };

--- a/src/types/dashboardProvideTypes.ts
+++ b/src/types/dashboardProvideTypes.ts
@@ -15,14 +15,14 @@ export const dashboardEventScheme = z.object({
     subtitle: z.string(),
     start_date: z.string(),
     end_date: z.string(),
-    discord_url: z.string().nullable(),
-    twitch_url: z.string().nullable(),
-    presskit_url: z.string().nullable(),
-    trailer_youtube_id: z.string().nullable(),
+    discord_url: z.string().nullable().transform((val) => val ?? ""),
+    twitch_url: z.string().nullable().transform((val) => val ?? ""),
+    presskit_url: z.string().nullable().transform((val) => val ?? ""),
+    trailer_youtube_id: z.string().nullable().transform((val) => val ?? ""),
     description_headline: z.string(),
     description: z.string(),
-    schedule_visible_from: z.string().nullable(),
-    publish_date: z.string().nullable(),
+    schedule_visible_from: z.string().nullable().transform((val) => val ?? ""),
+    publish_date: z.string().nullable().transform((val) => val ?? ""),
 })
 export type DashboardEvent = z.infer<typeof dashboardEventScheme>;
 

--- a/src/types/dashboardProvideTypes.ts
+++ b/src/types/dashboardProvideTypes.ts
@@ -8,3 +8,23 @@ export const dashboardRolesScheme = z.object({
     is_admin: z.boolean(),
 })
 export type DashboardRoles = z.infer<typeof dashboardRolesScheme>;
+
+export const dashboardEventScheme = z.object({
+    id: z.number(),
+    title: z.string(),
+    subtitle: z.string(),
+    start_date: z.string(),
+    end_date: z.string(),
+    discord_url: z.string().nullable(),
+    twitch_url: z.string().nullable(),
+    presskit_url: z.string().nullable(),
+    trailer_youtube_id: z.string().nullable(),
+    description_headline: z.string(),
+    description: z.string(),
+    schedule_visible_from: z.string().nullable(),
+    publish_date: z.string().nullable(),
+})
+export type DashboardEvent = z.infer<typeof dashboardEventScheme>;
+
+export const dashboardAllEventsScheme = z.array(dashboardEventScheme);
+export type DashboardAllEvents = z.infer<typeof dashboardAllEventsScheme>;

--- a/src/types/dashboardSetTypes.ts
+++ b/src/types/dashboardSetTypes.ts
@@ -1,3 +1,19 @@
 export type SetAdminGlobals = {
     footer_text: string;
 }
+
+export type SetAdminEvent = {
+    id: number,
+    title: string,
+    subtitle: string,
+    start_date: string,
+    end_date: string,
+    discord_url: string | null,
+    twitch_url: string | null,
+    presskit_url: string | null,
+    trailer_youtube_id: string | null,
+    description_headline: string,
+    description: string,
+    schedule_visible_from: string | null,
+    publish_date: string | null,
+}


### PR DESCRIPTION
### fix
- Use other http codes that 404 when I throw an error so that it recognizable.
- Make unsavedChangesPopup accessible from child pages

### new
- unsavedChangesPopup can now provide a save function when one is set in the store.
- `RAII-Wrapper` for providing save functions for unsavedChangesPopup.
- Display all event fields in the event dashboard
- A manual unsavedChangesPopup. The event dashboard is using this when switching the event with the drop down. 
- adds the possibility to add a new event.
- checks if the event title exists already.
- scrolls up when saving.
- displays error message when validation fails.
- validation of events.
- reload page when new event was successfully saved.

### not included
- Speaker 
