### PR TITLE
add facebook icon

### DIFF
--- a/src/lookup/iconLookup.ts
+++ b/src/lookup/iconLookup.ts
@@ -8,6 +8,7 @@ const lookup: IconDict = {
     Discord:     'fa-brands fa-discord',
     LinkedIn:    'fa-brands fa-linkedin',
     YouTube:     'fa-brands fa-youtube',
+    Facebook:    'fa-brands fa-facebook',
     Instagram:   'fa-brands fa-instagram',
     X:           'fa-brands fa-x-twitter',
     Git:         'fa-brands fa-git-alt',
@@ -18,7 +19,7 @@ const lookup: IconDict = {
     Calender:    'fa-solid fa-calendar-days',
     Clock:       'fa-solid fa-clock',
     CircleCross: 'fa-solid fa-circle-xmark',
-    CircleCheck: 'fa-solid fa-circle-check'
+    CircleCheck: 'fa-solid fa-circle-check',
 };
 
 export function iconLookup(type: string): string {


### PR DESCRIPTION
add the facebook icon.

I decided to use the round facebook icon instead of the raw f because the raw f is not squared.
That looked kinda weird.
Now Facebook ist the only round icon but I feel it fits better.

If you want to check the raw f for yourself:
- check out this branch
- replace `fa-facebook` with `fa-facebook-f` in the icon lookup
- add a facebook type somehow. Easiest was would be to seed this I think.