### PR TITLE
Front page

### DIFF
--- a/src/elements/input/yearEventLinks.svelte
+++ b/src/elements/input/yearEventLinks.svelte
@@ -9,27 +9,33 @@
 </script>
 
 <div class="year-event-links-wrapper {classes}">
-    <StyledLink
-          classes="styled-link-white"
-          href={data.year.event.discord_url}
-          title="Klicke hier, um auf den Discord-Server der Tech Stream Conference zu gelangen"
-          icon="Discord"
-          text="Sei dabei"
-    />
-    <StyledLink
-          classes="styled-link-white"
-          href={data.year.event.twitch_url}
-          title="Klicke hier, um auf die Twitch-Seite der Tech Stream Conference zu gelangen"
-          icon="Twitch"
-          text="Schau zu"
-    />
-    <StyledLink
-          classes="styled-link-white"
-          href={data.year.event.presskit_url}
-          title="Klicke hier, um das Presskit der Tech Stream Conference herunterzuladen"
-          icon="Download"
-          text="Presskit"
-    />
+    {#if data.year.event.discord_url}
+        <StyledLink
+              classes="styled-link-white"
+              href={data.year.event.discord_url}
+              title="Klicke hier, um auf den Discord-Server der Tech Stream Conference zu gelangen"
+              icon="Discord"
+              text="Sei dabei"
+        />
+    {/if}
+    {#if data.year.event.twitch_url}
+        <StyledLink
+              classes="styled-link-white"
+              href={data.year.event.twitch_url}
+              title="Klicke hier, um auf die Twitch-Seite der Tech Stream Conference zu gelangen"
+              icon="Twitch"
+              text="Schau zu"
+        />
+    {/if}
+    {#if data.year.event.presskit_url}
+        <StyledLink
+              classes="styled-link-white"
+              href={data.year.event.presskit_url}
+              title="Klicke hier, um das Presskit der Tech Stream Conference herunterzuladen"
+              icon="Download"
+              text="Presskit"
+        />
+    {/if}
 </div>
 
 <style>

--- a/src/forms/adminEventForm.svelte
+++ b/src/forms/adminEventForm.svelte
@@ -47,6 +47,7 @@
             publish_date:          checkSQLTimeAndDate(convertTimeAndDateToSQL(data.publish_date)),
             call_for_papers_start: checkSQLTimeAndDate(convertTimeAndDateToSQL(data.call_for_papers_start)),
             call_for_papers_end:   checkSQLTimeAndDate(convertTimeAndDateToSQL(data.call_for_papers_end)),
+            frontpage_date:        checkSQLTimeAndDate(convertTimeAndDateToSQL(data.frontpage_date)),
         };
     }
 
@@ -244,6 +245,14 @@
               type="datetime-local"
               ariaLabel="Gib das Veröffentlichungsdatum des ausgewählten Events ein."
               bind:value={event.publish_date}
+              on:input={setUnsavedChanges}
+        />
+        <Input
+              id="dashboard-admin-event-publish-frontend-event-date"
+              labelText="Veröffentlichungsdatum Frontpage:"
+              type="datetime-local"
+              ariaLabel="Gib das Veröffentlichungsdatum des ausgewählten Events auf der Frontpage ein."
+              bind:value={event.frontpage_date}
               on:input={setUnsavedChanges}
         />
         <Input

--- a/src/pages/year.svelte
+++ b/src/pages/year.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
     import * as Menu from 'menu/page';
+    import * as MenuItemPage from 'menu/pageItems';
+    import * as MenuItemDashboard from 'menu/dashboardItems';
 
     import type { LoadYear } from 'types/loadTypes';
     import type { Person, Talk } from 'types/provideTypes';
@@ -18,6 +20,8 @@
     import Schedule from 'elements/schedule/schedule.svelte';
     import StyledLink from 'elements/input/styledLink.svelte';
     import PageWrapper from 'elements/section/pageWrapper.svelte';
+    import TextLine from 'elements/text/textLine.svelte';
+    import Link from 'elements/text/link.svelte';
 
     import { formatDate } from 'helper/dates';
     import { apiUrl } from 'helper/links';
@@ -37,6 +41,22 @@
 
     function closePersonPopup(): void {
         personPopup.hide();
+    }
+
+
+    function lastEventLink(): string {
+        const currentIndex = data.globals.years_with_events.indexOf(data.year.event.year);
+        if (currentIndex === -1) { // no element found. displays main-page then.
+            console.error(`current year '${data.year.event.year}' not in globals array`);
+            return '';
+        }
+        if (currentIndex >= data.globals.years_with_events.length - 1) { // no previous year in the array. displays main-page then.
+            console.error(`no previous year for current year '${data.year.event.year}' not in globals array`);
+            return '';
+        }
+
+
+        return `/year/${data.globals.years_with_events[currentIndex + 1]}`;
     }
 
     function splitTalks(): ScheduleDay[] {
@@ -91,85 +111,164 @@
         </div>
     </div>
     <div class="year-content-wrapper">
-        <Section id="Trailer">
-            <div class="year-video-wrapper">
-                <YouTubeVideo
-                      id={data.year.event.trailer_youtube_id}
-                      title="Tech Stream Conference Trailer {data.year.event.year}"
-                />
-            </div>
-        </Section>
+        {#if data.year.event.trailer_youtube_id}
+            <Section id="Trailer">
+                <div class="year-video-wrapper">
+                    <YouTubeVideo
+                          id={data.year.event.trailer_youtube_id}
+                          title="Tech Stream Conference Trailer {data.year.event.year}"
+                    />
+                </div>
+            </Section>
+        {/if}
 
         <Section id="Description">
             <HeadlineH2 classes="headline-h2-border">{data.year.event.description_headline}</HeadlineH2>
             <div class="year-description-wrapper">
-                <div class="year-discription-text-wrapper">
+                <div class="year-description-text-wrapper">
                     <Paragraph classes="year-discription-paragraph paragraph-pre-wrap"
-                    >{data.year.event.description}</Paragraph
-                    >
+                    >{data.year.event.description}</Paragraph>
                     <YearEventLinks {data} />
                 </div>
                 <LogoBig classes="year-logo-big" />
             </div>
         </Section>
 
-        <Section id="Speaker">
-            <HeadlineH2 classes="headline-h2-border">Vortragende</HeadlineH2>
-            <div class="year-section-inner">
-                <PersonArray personData={data.year.speakers}
-                             personPopupCallback={openPersonPopup} />
-            </div>
-        </Section>
+        {#if !data.year.event.is_visible_on_frontpage}
+            <Section>
+                <div class="year-section-inner">
+                    <HeadlineH2 classes="headline-h2-border">Noch in Planung</HeadlineH2>
+                    <Paragraph --text-align="center">
+                        Wir sind gerade mitten in der Planung des nächsten Events.<br />
+                        Du kannst dich
+                        {#if data.year.event.call_for_papers_start && data.year.event.call_for_papers_end}
+                            vom {formatDate(
+                              data.year.event.call_for_papers_start,
+                              '%DD.%MM.'
+                        )} bis {formatDate(data.year.event.call_for_papers_end, '%DD.%MM.%YYYY')}
+                        {/if}
+                        als Speaker bewerben und einen Vortrag einreichen.<br />
+                        {#if data.loggedIn}
+                            Bewirb dich im
+                            <Link classes="link-inline"
+                                  href={MenuItemDashboard.userApplication.url}
+                                  title={MenuItemDashboard.userApplication.description}>User-Dashboard
+                            </Link>
+                            als Speaker.<br /><br /> Du bist bereits Speaker?<br /> Dann kannst du im
+                            <Link classes="link-inline"
+                                  href={MenuItemDashboard.speakerApplication.url}
+                                  title={MenuItemDashboard.speakerApplication.description}>Speaker-Dashboard
+                            </Link>
+                            einen Talk einreichen.
+                        {:else}
+                            <Link classes="link-inline"
+                                  href={MenuItemPage.login.url}
+                                  title={MenuItemPage.login.description}>Melde dich dafür an
+                            </Link>
+                            oder
+                            <Link classes="link-inline"
+                                  href={MenuItemPage.register.url}
+                                  title={MenuItemPage.register.description}>registriere
+                            </Link>
+                            einen neuen Account.
+                        {/if}
+                        <br /><br />Oder schau dir in der Zwischenzeit
+                        <Link classes="link-inline"
+                              href={lastEventLink()}
+                              title="Klicke hier, um dir die Hauptseite des letzten Events anzeigen zu lassen">
+                            unser letztes Event
+                        </Link>
+                        an.
+                    </Paragraph>
+                </div>
+            </Section>
+        {/if}
 
-        <Section id="Sponsors">
-            <HeadlineH2 classes="headline-h2-border">Sponsoren</HeadlineH2>
-            <div class="year-section-inner">
-                <SponsorArray logos={data.year.sponsors} />
-            </div>
-        </Section>
+        {#if data.year.event.is_visible_on_frontpage}
+            <Section id="Speaker">
+                <HeadlineH2 classes="headline-h2-border">Vortragende</HeadlineH2>
+                <div class="year-section-inner">
+                    {#if data.year.speakers.length > 0}
+                        <PersonArray personData={data.year.speakers}
+                                     personPopupCallback={openPersonPopup} />
+                    {:else}
+                        <TextLine classes="text-line-center">Sei gespannt welche Speaker in den nächsten Tagen hier auf
+                                                             dich warten.
+                        </TextLine>
+                    {/if}
+                </div>
+            </Section>
+        {/if}
 
-        <Section>
-            <HeadlineH2 classes="headline-h2-border">Medienpartner</HeadlineH2>
-            <div class="year-section-inner">
-                <SponsorArray logos={data.year.media_partners} />
-            </div>
-        </Section>
+        {#if data.year.sponsors.length > 0}
+            <Section id="Sponsors">
+                <HeadlineH2 classes="headline-h2-border">Sponsoren</HeadlineH2>
+                <div class="year-section-inner">
+                    <SponsorArray logos={data.year.sponsors} />
+                </div>
+            </Section>
+        {/if}
 
-        <Section id="Team">
-            <HeadlineH2 classes="headline-h2-border">Team</HeadlineH2>
-            <div class="year-section-inner">
-                <PersonArray personData={data.year.team_members}
-                             personPopupCallback={openPersonPopup} />
-            </div>
-        </Section>
+        {#if data.year.media_partners.length > 0}
+            <Section>
+                <HeadlineH2 classes="headline-h2-border">Medienpartner</HeadlineH2>
+                <div class="year-section-inner">
+                    <SponsorArray logos={data.year.media_partners} />
+                </div>
+            </Section>
+        {/if}
 
-        <Section id="Schedule">
-            <HeadlineH2 classes="headline-h2-border">Plan</HeadlineH2>
-            <div class="center-styled-link">
-                <StyledLink
-                      classes="styled-link-white"
-                      href={apiUrl(`/events/${data.year.event.year}/ics`)}
-                      title="Klicke um den Ablaufplan als ICS-Datei herunter zu laden"
-                      icon="Calender"
-                      newTab={false}
-                      text="Verpasse keinen Vortrag und hole dir jetzt alle Termine in deinen Kalender. Klicke hier!"
-                />
-            </div>
-            <div class="year-section-inner">
-                {#each splitTalks() as days}
-                    <Schedule
-                          schedule={days.normal}
-                          speakers={data.year.speakers}
-                          personPopupCallback={openPersonPopup}
-                    />
-                    <Schedule
-                          schedule={days.special}
-                          speakers={data.year.speakers}
-                          personPopupCallback={openPersonPopup}
-                    />
-                {/each}
-            </div>
-        </Section>
+        {#if data.year.event.is_visible_on_frontpage}
+            <Section id="Team">
+                <HeadlineH2 classes="headline-h2-border">Team</HeadlineH2>
+                <div class="year-section-inner">
+                    {#if data.year.team_members.length > 0}
+                        <PersonArray personData={data.year.team_members}
+                                     personPopupCallback={openPersonPopup} />
+                    {:else}
+                        <TextLine classes="text-line-center">Sei gespannt welche Team Member in den nächsten Tagen hier
+                                                             auf dich warten.
+                        </TextLine>
+                    {/if}
+                </div>
+            </Section>
+        {/if}
+
+        {#if data.year.event.is_visible_on_frontpage}
+            <Section id="Schedule">
+                <HeadlineH2 classes="headline-h2-border">Plan</HeadlineH2>
+                {#if data.year.talks.length > 0}
+                    <div class="center-styled-link">
+                        <StyledLink
+                              classes="styled-link-white"
+                              href={apiUrl(`/events/${data.year.event.year}/ics`)}
+                              title="Klicke um den Ablaufplan als ICS-Datei herunter zu laden"
+                              icon="Calender"
+                              newTab={false}
+                              text="Verpasse keinen Vortrag und hole dir jetzt alle Termine in deinen Kalender. Klicke hier!"
+                        />
+                    </div>
+                    <div class="year-section-inner">
+                        {#each splitTalks() as days}
+                            <Schedule
+                                  schedule={days.normal}
+                                  speakers={data.year.speakers}
+                                  personPopupCallback={openPersonPopup}
+                            />
+                            <Schedule
+                                  schedule={days.special}
+                                  speakers={data.year.speakers}
+                                  personPopupCallback={openPersonPopup}
+                            />
+                        {/each}
+                    </div>
+                {:else}
+                    <TextLine classes="text-line-center">Sei gespannt welche Team Member in den nächsten Tagen hier
+                                                         auf dich warten.
+                    </TextLine>
+                {/if}
+            </Section>
+        {/if}
     </div>
 </PageWrapper>
 
@@ -215,10 +314,11 @@
         margin-top:     var(--2x-margin);
     }
 
-    .year-discription-text-wrapper {
+    .year-description-text-wrapper {
         display:        flex;
         flex-direction: column;
         margin-right:   var(--2x-margin);
+        flex-grow:      1;
     }
 
     :global(.year-discription-paragraph) {
@@ -228,6 +328,7 @@
     .year-content-wrapper {
         flex-grow: 1;
         max-width: 150rem;
+        width:     100%;
         margin:    0 auto 10rem;
         padding:   0 var(--2x-padding);
     }
@@ -259,7 +360,7 @@
             margin-left: 0;
         }
 
-        .year-discription-text-wrapper {
+        .year-description-text-wrapper {
             margin-right: 0;
         }
 

--- a/src/pages/year.svelte
+++ b/src/pages/year.svelte
@@ -192,7 +192,7 @@
                         <PersonArray personData={data.year.speakers}
                                      personPopupCallback={openPersonPopup} />
                     {:else}
-                        <TextLine classes="text-line-center">Sei gespannt welche Speaker in den nächsten Tagen hier auf
+                        <TextLine classes="text-line-center">Sei gespannt, welche Speaker in den nächsten Tagen hier auf
                                                              dich warten.
                         </TextLine>
                     {/if}
@@ -226,7 +226,7 @@
                         <PersonArray personData={data.year.team_members}
                                      personPopupCallback={openPersonPopup} />
                     {:else}
-                        <TextLine classes="text-line-center">Sei gespannt welche Team Member in den nächsten Tagen hier
+                        <TextLine classes="text-line-center">Sei gespannt welche, Team Member in den nächsten Tagen hier
                                                              auf dich warten.
                         </TextLine>
                     {/if}
@@ -242,7 +242,7 @@
                         <StyledLink
                               classes="styled-link-white"
                               href={apiUrl(`/events/${data.year.event.year}/ics`)}
-                              title="Klicke um den Ablaufplan als ICS-Datei herunter zu laden"
+                              title="Klicke, um den Ablaufplan als ICS-Datei herunterzuladen"
                               icon="Calender"
                               newTab={false}
                               text="Verpasse keinen Vortrag und hole dir jetzt alle Termine in deinen Kalender. Klicke hier!"
@@ -263,7 +263,7 @@
                         {/each}
                     </div>
                 {:else}
-                    <TextLine classes="text-line-center">Sei gespannt welche Team Member in den nächsten Tagen hier
+                    <TextLine classes="text-line-center">Sei gespannt, welche Vorträge in den nächsten Tagen hier
                                                          auf dich warten.
                     </TextLine>
                 {/if}

--- a/src/routes/dashboard/admin/events/+page.svelte
+++ b/src/routes/dashboard/admin/events/+page.svelte
@@ -59,6 +59,7 @@
         currentEvent.schedule_visible_from = convertTimeAndDateToHTML(currentEvent.schedule_visible_from);
         currentEvent.call_for_papers_start = convertTimeAndDateToHTML(currentEvent.call_for_papers_start);
         currentEvent.call_for_papers_end   = convertTimeAndDateToHTML(currentEvent.call_for_papers_end);
+        currentEvent.frontpage_date        = convertTimeAndDateToHTML(currentEvent.frontpage_date);
 
         vdoLinks = undefined;
 

--- a/src/types/dashboardProvideTypes.ts
+++ b/src/types/dashboardProvideTypes.ts
@@ -77,6 +77,9 @@ export const dashboardEventScheme = z.object({
                                                  call_for_papers_end:   z.string()
                                                                          .nullable()
                                                                          .transform((val) => val ?? ''),
+                                                 frontpage_date:        z.string()
+                                                                         .nullable()
+                                                                         .transform((val) => val ?? ''),
 
                                              });
 export type DashboardEvent = z.infer<typeof dashboardEventScheme>;

--- a/src/types/dashboardSetTypes.ts
+++ b/src/types/dashboardSetTypes.ts
@@ -18,6 +18,7 @@ export type SetAdminEvent = {
     publish_date: string | null,
     call_for_papers_start: string | null,
     call_for_papers_end: string | null,
+    frontpage_date: string | null,
 }
 
 export type SetAdminEventSpeaker = {

--- a/src/types/provideTypes.ts
+++ b/src/types/provideTypes.ts
@@ -63,18 +63,21 @@ export const talkScheme = z.object({
 export type Talk = z.infer<typeof talkScheme>;
 
 export const eventScheme = z.object({
-                                        id:                   z.number(),
-                                        year:                 z.number(),
-                                        title:                z.string(),
-                                        subtitle:             z.string(),
-                                        start_date:           z.string(),
-                                        end_date:             z.string(),
-                                        description_headline: z.string(),
-                                        description:          z.string(),
-                                        discord_url:          z.string(),
-                                        twitch_url:           z.string(),
-                                        presskit_url:         z.string(),
-                                        trailer_youtube_id:   z.string(),
+                                        id:                      z.number(),
+                                        year:                    z.number(),
+                                        title:                   z.string(),
+                                        subtitle:                z.string(),
+                                        start_date:              z.string(),
+                                        end_date:                z.string(),
+                                        description_headline:    z.string(),
+                                        description:             z.string(),
+                                        discord_url:             z.string().nullable(),
+                                        twitch_url:              z.string().nullable(),
+                                        presskit_url:            z.string().nullable(),
+                                        trailer_youtube_id:      z.string().nullable(),
+                                        is_visible_on_frontpage: z.boolean(),
+                                        call_for_papers_start:   z.string().nullable(),
+                                        call_for_papers_end:     z.string().nullable(),
                                     });
 export type Event = z.infer<typeof eventScheme>;
 


### PR DESCRIPTION
close #182 
close #183 

- adds `frontpage_date` to admin dashboard
- adds nullable values to frontpage
- adds `is_displayed_on_frontpage` to frontpage

- note: The frontpage text when `is_diaplayed_on_frontpage` differs when logged in because you can navigate directly to the dashboard.
- note: this frontend breaks the speaker tab this the corresponding backend pr.  But the admin dashboard and the frontpage works just fine. the error is not occurring when using a newer backend. So I think we can ignore it.