### PR TITLE
feat: vite base url

### DIFF
--- a/src/helper/links.ts
+++ b/src/helper/links.ts
@@ -1,4 +1,9 @@
 export function apiUrl(link: string): string {
+    const base_url = import.meta.env.VITE_API_BASE_URL;
+    if (base_url){
+        return `${base_url}${link}`;
+    }
+    console.error(`VITE_API_BASE_URL is undefined. default to local host.`);
     return 'http://localhost:8080/api' + link;
 }
 


### PR DESCRIPTION
close #174 

I managed to be able to set a env variable via vite.
I dont now it this is appropriate for deploying the site.
You have to test that.

But now you can set the `VITE_API_BASE_URL` via the terminal and as long as the terminal runs vite will use this url. even when npm gets restarted.

Use this command to set the url: $env:VITE_API_BASE_URL="/*base api goes here*/"
After that you can start npm like normal.
It will default to localhost when url is undefined. you can see that at the console.

note: the base use is supposed to  define everything that is not a CodeIgniter route. including the protocol.


check that out and try if it is working for our deployment or not.