### PR TITLE
189 issue with some texts

### DIFF
--- a/src/elements/section/sectionDashboard.svelte
+++ b/src/elements/section/sectionDashboard.svelte
@@ -20,4 +20,8 @@
         flex-direction: column;
         gap:            var(--full-gap);
     }
+
+    .wide-dashboard-section-override {
+        max-width: 150rem !important;
+    }
 </style>

--- a/src/routes/dashboard/admin/create-panel-discussion/+page.svelte
+++ b/src/routes/dashboard/admin/create-panel-discussion/+page.svelte
@@ -97,7 +97,7 @@
       entries={Menu.admin}
       entryName={MenuItem.adminCreatePanelDiscussion.name} />
 
-<SectionDashboard classes="standard-dashboard-section">
+<SectionDashboard classes="standard-dashboard-section wide-dashboard-section-override">
     {#if currentState === State.Default}
         <NavigationDropDown bind:this={eventDropDown}
                             labelText="Aktuelles Jahr:"

--- a/src/routes/dashboard/speaker/application/+page.svelte
+++ b/src/routes/dashboard/speaker/application/+page.svelte
@@ -13,6 +13,11 @@
     import SectionDashboard from 'elements/section/sectionDashboard.svelte';
     import Explanation from 'elements/text/explanation.svelte';
     import SubHeadline from 'elements/text/subHeadline.svelte';
+    import Paragraph from 'elements/text/paragraph.svelte';
+    import Link from 'elements/text/link.svelte';
+
+    const APPLY_ERROR_NO_SPEAKER: string              = 'NO_APPROVED_SPEAKER_ENTRY';
+     // const APPLY_ERROR_CURRENTLY_NOT_ACCEPTING: string = 'CURRENTLY_NOT_ACCEPTING_SPEAKER_APPLICATIONS'; // default state
 
     export let data: LoadSpeakerApplication;
     let saved: boolean = false;
@@ -74,8 +79,24 @@
                              talkDurations={data.talkDurations}
                              on:save={() => saved = true} />
         {:else}
-            <TextLine>Aktuell kannst du keinen Talk einreichen.</TextLine>
-            <TextLine>Versuche es gerne bei der nächsten Bewerbungsphase wieder.</TextLine>
+            {#if data.applyError === APPLY_ERROR_NO_SPEAKER}
+                <Paragraph --text-align="center">
+                    Du bist noch kein Speaker für das aktuelle Event.<br />Aber gute Neuigkeiten für dich: Das kannst du
+                    ganz einfach ändern.<br />
+                    Bewerbe dich gerne für das aktuelle Event im
+                    <Link classes="link-inline"
+                          title={MenuItem.userApplication.description}
+                          href={MenuItem.userApplication.url}>User Dashboard.
+                    </Link>
+                    <br /><br />Du hast dich bereits für dieses Jahr
+                    beworben?<br /> Dann hab gerne etwas Geduld. Wir arbeiten dran.
+                </Paragraph>
+            {:else}
+                <Paragraph --text-align="center">
+                    Aktuell nehmen wir keine neuen Talk Bewerbungen an.<br />
+                    Versuche es gerne bei der nächsten Bewerbungsphase wieder.
+                </Paragraph>
+            {/if}
         {/if}
     {/if}
 </SectionDashboard>

--- a/src/routes/dashboard/speaker/application/+page.svelte
+++ b/src/routes/dashboard/speaker/application/+page.svelte
@@ -83,17 +83,17 @@
                 <Paragraph --text-align="center">
                     Du bist noch kein Speaker für das aktuelle Event.<br />Aber gute Neuigkeiten für dich: Das kannst du
                     ganz einfach ändern.<br />
-                    Bewerbe dich gerne für das aktuelle Event im
+                    Bewirb dich gerne für das aktuelle Event im
                     <Link classes="link-inline"
                           title={MenuItem.userApplication.description}
-                          href={MenuItem.userApplication.url}>User Dashboard.
+                          href={MenuItem.userApplication.url}>User-Dashboard.
                     </Link>
                     <br /><br />Du hast dich bereits für dieses Jahr
                     beworben?<br /> Dann hab gerne etwas Geduld. Wir arbeiten dran.
                 </Paragraph>
             {:else}
                 <Paragraph --text-align="center">
-                    Aktuell nehmen wir keine neuen Talk Bewerbungen an.<br />
+                    Aktuell nehmen wir keine neuen Talks an.<br />
                     Versuche es gerne bei der nächsten Bewerbungsphase wieder.
                 </Paragraph>
             {/if}

--- a/src/routes/dashboard/speaker/application/+page.svelte
+++ b/src/routes/dashboard/speaker/application/+page.svelte
@@ -16,8 +16,9 @@
     import Paragraph from 'elements/text/paragraph.svelte';
     import Link from 'elements/text/link.svelte';
 
-    const APPLY_ERROR_NO_SPEAKER: string              = 'NO_APPROVED_SPEAKER_ENTRY';
-     // const APPLY_ERROR_CURRENTLY_NOT_ACCEPTING: string = 'CURRENTLY_NOT_ACCEPTING_SPEAKER_APPLICATIONS'; // default state
+    // Standard Apply Error is 'CURRENTLY_NOT_ACCEPTING_SPEAKER_APPLICATIONS'.
+    // This error is the else path to make sure at least one error message is displayed.
+    const APPLY_ERROR_NO_SPEAKER: string = 'NO_APPROVED_SPEAKER_ENTRY';
 
     export let data: LoadSpeakerApplication;
     let saved: boolean = false;

--- a/src/routes/dashboard/speaker/application/+page.svelte
+++ b/src/routes/dashboard/speaker/application/+page.svelte
@@ -50,7 +50,7 @@
       entryName={MenuItem.speakerApplication.name}
       classes="navigation-tabs-dashboard-subpage" />
 
-<SectionDashboard classes="standard-dashboard-section">
+<SectionDashboard classes="standard-dashboard-section wide-dashboard-section-override">
     <Explanation>
         Hier kannst du ein Thema für einen Vortrag einreichen, den du gerne bei unserem Event halten möchtest. Trage
         dafür deine Daten unten ein. Wenn du deinen Vortrag eingereicht hast, wird er von uns geprüft und wir werden uns

--- a/src/routes/dashboard/speaker/application/+page.ts
+++ b/src/routes/dashboard/speaker/application/+page.ts
@@ -1,6 +1,7 @@
 import type { LoadSpeakerApplication } from 'types/dashboardLoadTypes';
+
 import { apiUrl } from 'helper/links';
-import { checkAndParseInputDataAsync } from 'helper/parseJson';
+import { checkAndParseInputDataAsync, parseMultipleInfosAsync } from 'helper/parseJson';
 import { allTalkTagScheme } from 'types/provideTypes';
 import { dashboardEventScheme, dashboardTalkDurationChoicesScheme } from 'types/dashboardProvideTypes';
 import { z } from 'zod';
@@ -13,8 +14,10 @@ export async function load({ fetch }: {
     const allTalkDurationFetchPromise = fetch(apiUrl('/talk-duration-choices'));
 
     if (!(await canApplyFetchPromise).ok) { // not able for current speaker to apply a talk
+        const errors = await parseMultipleInfosAsync(await canApplyFetchPromise);
         return {
             canApply:      false,
+            applyError:    errors['error'],
             event:         undefined,
             tags:          [],
             talkDurations: [],
@@ -44,6 +47,7 @@ export async function load({ fetch }: {
 
     return {
         canApply:      (await canApplyParsePromise).can_submit_talk,
+        applyError:    '',
         event:         (await canApplyParsePromise).event,
         tags:          await allTagsParsePromise,
         talkDurations: await allTalkDurationParsePromise,

--- a/src/routes/dashboard/speaker/talk/+page.svelte
+++ b/src/routes/dashboard/speaker/talk/+page.svelte
@@ -106,7 +106,7 @@
                   rejectSlot(index);}}
               denyCallback={() => {}} />
 
-<SectionDashboard classes="standard-dashboard-section">
+<SectionDashboard classes="standard-dashboard-section wide-dashboard-section-override">
     <Explanation>
         Du siehst hier die Vorträge, die du eingereicht hast. Wähle zunächst über das Dropdown-Menü das Event aus. Wenn ein Talk von uns akzeptiert wurde, kannst du daran keine Änderungen mehr vornehmen.
     </Explanation>

--- a/src/types/dashboardLoadTypes.ts
+++ b/src/types/dashboardLoadTypes.ts
@@ -100,6 +100,7 @@ export type LoadSpeakerTalk = {
 
 export type LoadSpeakerApplication = {
     canApply: boolean,
+    applyError: string,
     event: DashboardEvent | undefined,
     tags: AllTalkTag,
     talkDurations: DashboardTalkDurationChoices,


### PR DESCRIPTION
close #189 

adds a new text für the talk application page when a speaker is no speaker for the current event,
Even if a speaker has a pending application for the current year.

Also makes all Talk related dashboard pages a litte wider because this form needs some more space.
