### PR TITLE
Forward x real ip during ssr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,13 @@ RUN echo 'alias ll="ls -la"' >> ~/.bashrc
 
 # --- Development target ---
 FROM base AS dev
-
+WORKDIR /app
 COPY package*.json ./
 RUN npm install
+RUN cp -r node_modules /node_modules.bak
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 # Source files will be mounted from the host, we don't copy them here.
 CMD ["npm", "run", "dev", "--", "--host"]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+if [ ! -d "./node_modules" ]; then
+  echo "'node_modules' not found in volume, restoring from image..."
+  cp -v -r /node_modules.bak ./node_modules
+fi
+
+exec "$@"

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -21,15 +21,14 @@ export const handleFetch: HandleFetch = async ({ event, request, fetch }) => {
     );
     request.headers.set('cookie', cookies!);
 
-    if (dev) {
-        request.headers.set('x-real-ip', '127.0.0.1');
-    } else {
-        const ip = event.request.headers.get('x-real-ip');
-        if (!ip) {
-            console.error('[handleFetch] x-real-ip header is missing.');
-            throw error(500);
-        }
+    const ip = event.request.headers.get('x-real-ip');
+    if (ip) {
         request.headers.set('x-real-ip', ip);
+    } else if (!dev) {
+        console.error('[handleFetch] x-real-ip header is missing.');
+        throw error(500);
+    } else {
+        request.headers.set('x-real-ip', '127.0.0.1');
     }
     return fetch(request);
 };

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -18,5 +18,6 @@ export const handleFetch: HandleFetch = async ({ event, request, fetch }) => {
         request
     );
     request.headers.set('cookie', cookies!);
+    request.headers.set('x-real-ip', event.request.headers.get('x-real-ip') || '');
     return fetch(request);
 };

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,8 +1,10 @@
-import type { HandleFetch } from '@sveltejs/kit';
+import {error, type HandleFetch} from '@sveltejs/kit';
 import { env } from '$env/dynamic/public';
+import {dev} from "$app/environment";
 
 export const handleFetch: HandleFetch = async ({ event, request, fetch }) => {
     const cookies = event.request.headers.get("cookie")
+    console.log(`[handleFetch] cookies: ${cookies}`);
     if (!env.PUBLIC_API_BASE_URL_SSR) {
         console.error('[handleFetch] env.PUBLIC_API_BASE_URL_SSR is not set.');
         return fetch(request);
@@ -18,6 +20,16 @@ export const handleFetch: HandleFetch = async ({ event, request, fetch }) => {
         request
     );
     request.headers.set('cookie', cookies!);
-    request.headers.set('x-real-ip', event.request.headers.get('x-real-ip') || '');
+
+    if (dev) {
+        request.headers.set('x-real-ip', '127.0.0.1');
+    } else {
+        const ip = event.request.headers.get('x-real-ip');
+        if (!ip) {
+            console.error('[handleFetch] x-real-ip header is missing.');
+            throw error(500);
+        }
+        request.headers.set('x-real-ip', ip);
+    }
     return fetch(request);
 };


### PR DESCRIPTION
This PR includes two things:
- Changes regarding the Docker setup.
- The frontend passes along the `x-real-ip` header that it gets from the reverse proxy. This is required for the rate limiting (in the backend) to work.