### PR TITLE
feat: add "vergeben" tag to time slots

### DIFF
--- a/src/forms/adminTentativeTalkApprovalForm.svelte
+++ b/src/forms/adminTentativeTalkApprovalForm.svelte
@@ -87,6 +87,7 @@
         errorList = result.messages;
         if (result.success) {
             talk.suggested_time_slot = getElementByID(slots[talk.event_id], id);
+            talk.suggested_time_slot.is_occupied = true;
             dispatch('suggest');
         }
     }

--- a/src/forms/adminTentativeTalkApprovalForm.svelte
+++ b/src/forms/adminTentativeTalkApprovalForm.svelte
@@ -86,6 +86,7 @@
         message.setSaveMessage(result.success ? SaveMessageType.Save : SaveMessageType.Error);
         errorList = result.messages;
         if (result.success) {
+            getElementByID(slots[talk.event_id], talk.suggested_time_slot.id).is_occupied = false;
             talk.suggested_time_slot = getElementByID(slots[talk.event_id], id);
             talk.suggested_time_slot.is_occupied = true;
             dispatch('suggest');

--- a/src/forms/adminTentativeTalkApprovalForm.svelte
+++ b/src/forms/adminTentativeTalkApprovalForm.svelte
@@ -42,7 +42,11 @@
         if (!slot) {
             return '';
         }
-        return `${slot.id} | ${formatDate(slot.start_time, '%DD.%MM.%YYYY %hh:%mm')} | ${slot.duration} Minuten`;
+        let entry = `${slot.id} | ${formatDate(slot.start_time, '%DD.%MM.%YYYY %hh:%mm')} | ${slot.duration} Minuten`;
+        if (slot.is_occupied) {
+            entry+= ' | Vergeben';
+        }
+        return entry;
     }
 
     function getIDFromDropDownCurrentEntry(): number {

--- a/src/forms/adminTentativeTalkApprovalFormWrapper.svelte
+++ b/src/forms/adminTentativeTalkApprovalFormWrapper.svelte
@@ -18,7 +18,7 @@
         </SubHeadline>
         {#each talks as talk}
             <AdminTentativeTalkApprovalForm {talk}
-                                            {slots}
+                                            bind:slots={slots}
                                             on:reject={()=> dispatch('reject', talk.id)}
                                             on:suggest={()=> dispatch('suggest', talk.id)} />
         {/each}

--- a/src/routes/dashboard/admin/approval-talk/+page.svelte
+++ b/src/routes/dashboard/admin/approval-talk/+page.svelte
@@ -95,7 +95,7 @@
                                                  on:reject={(e) => deleteEntry(DataType.Pending, e.detail)}
                                                  on:approve={(e) => moveTalk(e.detail)} />
             <AdminTentativeTalkApprovalFormWrapper talks={getElementsByUserID(data.tentativeTalks, userID)}
-                                                   slots={data.slots}
+                                                   bind:slots={data.slots}
                                                    on:reject={(e) => deleteEntry(DataType.Tentative, e.detail)} />
         </div>
     {/each}

--- a/src/types/dashboardProvideTypes.ts
+++ b/src/types/dashboardProvideTypes.ts
@@ -185,6 +185,9 @@ export const dashboardTimeSlotScheme = z.object({
                                                     event_id:   z.number(),
                                                     start_time: z.string(),
                                                     duration:   z.number(),
+                                                    is_occupied: z.boolean()
+                                                        .optional()
+                                                        .transform(x => x ?? false),
                                                     is_special: z.boolean(),
                                                 });
 export type DashboardTimeSlot = z.infer<typeof dashboardTimeSlotScheme>;


### PR DESCRIPTION
close #151

at the dropdown where you suggest the timeslot a "vergeben" is added to each occupied slot.
as you can see is not best practice that `is_occupied` can be undefined.
I set it myself to false now when it is undefined.

We can leave it like this. This will work.
It would be cleaner when you would set the value always and I just check it.
We can discuss that.

Do we need that `is_occupied` flag at an other page two?
Im not quite sure.