### PR TITLE
Mobile menu entries

### DIFF
--- a/src/elements/navigation/header.svelte
+++ b/src/elements/navigation/header.svelte
@@ -77,6 +77,7 @@
                             classes="link-standard navigation-header-link"
                             href={entry.url}
                             title={entry.description}
+                            --text-align="center"
                             on:click={collapse}>{entry.name}</Link
                     >
                 {/each}
@@ -226,7 +227,6 @@
         :global(.navigation-header-link) {
             text-transform: uppercase;
             color: var(--white-color);
-            align-self: end !important;
         }
     }
 </style>

--- a/src/elements/navigation/header.svelte
+++ b/src/elements/navigation/header.svelte
@@ -227,6 +227,7 @@
         :global(.navigation-header-link) {
             text-transform: uppercase;
             color: var(--white-color);
+            width: 100%;
         }
     }
 </style>


### PR DESCRIPTION
close #233 

this addresses two feedbacks for the mobile menu.
first, that not the hole width was clickable
second, that the entries where not centered.