### PR TITLE
266 remove anmelden button

### DIFF
--- a/src/routes/register/+page.svelte
+++ b/src/routes/register/+page.svelte
@@ -200,7 +200,7 @@
                 </Paragraph>
                 <div class="button-wrapper">
                     <a href="/">
-                        <Button ariaLabel="Klicke, um zur aktuellen Hauptseite zu gelangen">Start</Button>
+                        <Button ariaLabel="Klicke, um zur aktuellen Hauptseite zu gelangen">Hauptseite</Button>
                     </a>
                 </div>
             </div>

--- a/src/routes/register/+page.svelte
+++ b/src/routes/register/+page.svelte
@@ -202,9 +202,6 @@
                     <a href="/">
                         <Button ariaLabel="Klicke, um zur aktuellen Hauptseite zu gelangen">Start</Button>
                     </a>
-                    <a href="./login">
-                        <Button ariaLabel="Klicke, um dich anzumelden">Anmelden</Button>
-                    </a>
                 </div>
             </div>
         {/if}


### PR DESCRIPTION
close #266 

Some get confused because of the main page button name and the log in button even tho the mail provides a link. The verify Page also provide a login button.
So the login button here was basically confusing since the login will not work until opening the link provided by the mail.
So I just removed it.

To easily test that.
Just set the variable `registered` to `true`.
`+page` of the 'register' directory.
Line 48.