### PR TITLE
fix: remove reactive block, that always resets the picture when other…

### DIFF
--- a/src/forms/speakerTeamMemberEventForm.svelte
+++ b/src/forms/speakerTeamMemberEventForm.svelte
@@ -41,10 +41,6 @@
         return cropperProps;
     }
 
-    $: if (data.event.photo) {
-        resetImage();
-    }
-
     function changeImage(event: Event): void {
         if (!event.target) {
             resetImage();


### PR DESCRIPTION
… data in event are set

close #269 

I removed this reactive block because it also triggers when `data.event` changes somehow.
Because the other inputs also write into this variable, it also clears the image automatically.

That means when the backend would inject a new picture into this side. It would not change anymore.
But since the user is the only one changing the image here, I think that this is okay.