### PR TITLE
fix: add a z-index for the tooltop

### DIFF
--- a/src/elements/text/tooltip.svelte
+++ b/src/elements/text/tooltip.svelte
@@ -71,5 +71,6 @@
         padding: var(--full-padding);
         position: absolute;
         transform: translateX(-50%) translateY(3rem); /* Center the tooltip horizontally */
+        z-index: 1000;
     }
 </style>


### PR DESCRIPTION
Just found a z-index error.
The tooltip was rendered under other stuff. 
e.g. At the social dashboard. 