### PR TITLE
300 restrict lengths of talk titles and descriptions

### DIFF
--- a/src/elements/input/textArea.svelte
+++ b/src/elements/input/textArea.svelte
@@ -1,3 +1,7 @@
+<script context="module" lang="ts">
+    export const NO_LIMIT = -1;
+</script>
+
 <script lang="ts">
     import {createEventDispatcher} from "svelte";
     import {lerpTextCountColor} from "helper/color";
@@ -14,7 +18,6 @@
     export let labelText: string;
     export let placeholderText: string = " ";
 
-    export const NO_LIMIT = -1;
     export let limit: number = NO_LIMIT;
 
     let colorString: string;

--- a/src/forms/speakerTalkForm.svelte
+++ b/src/forms/speakerTalkForm.svelte
@@ -8,6 +8,7 @@
     import {trySaveDataAsync} from 'helper/trySaveData';
     import {SaveMessageType} from 'types/saveMessageType';
     import {createEventDispatcher} from 'svelte';
+    import {NO_LIMIT} from 'elements/input/textArea.svelte';
 
     import TagArray from 'elements/input/tagArray.svelte';
     import Message from 'elements/text/message.svelte';
@@ -26,6 +27,7 @@
     export let tags: AllTalkTag;
     export let talkDurations: DashboardTalkDurationChoices;
     export let useForm: boolean = true;
+    export let isAdmin: boolean = false;
 
     // @formatter:off
     let saveMessage: SaveMessage;
@@ -89,7 +91,8 @@
                   ariaLabel="Gib hier die Beschreibung des Talks ein"
                   bind:value={data.description}
                   on:input={setUnsavedChanges}
-                  on:submit={save}/>
+                  on:submit={save}
+                  limit={isAdmin ? NO_LIMIT : 280}/>
         <Paragraph classes="paragraph-gray">Beschreibe deinen Vortrag. Hier darfst du gerne etwas mehr ins Detail gehen.
             Worum geht es in deinem Vortrag? Was wird man dabei lernen? Was ist das
             Besondere an deinem Vortrag? Eine

--- a/src/forms/speakerTalkForm.svelte
+++ b/src/forms/speakerTalkForm.svelte
@@ -22,6 +22,10 @@
     import FormWrapper from 'elements/wrapper/formWrapper.svelte';
     import Paragraph from 'elements/text/paragraph.svelte';
 
+    const YOUTUBE_VIDEO_TITLE_LENGTH = 100;
+    const YOUTUBE_VIDEO_TITLE_FIXED_PART = " –  – TECH STREAM CONFERENCE"
+    const DESCRIPTION_LIMIT = 280;
+
     export let classes: string = '';
     export let data: DashboardPendingTalk;
     export let tags: AllTalkTag;
@@ -81,7 +85,7 @@
                ariaLabel="Gib hier den Titel des Talks ein"
                bind:value={data.title}
                on:input={setUnsavedChanges}
-               limit={100-28-data.speaker.name.length}/>
+               limit={YOUTUBE_VIDEO_TITLE_LENGTH-YOUTUBE_VIDEO_TITLE_FIXED_PART.length-data.speaker.name.length}/>
         <Paragraph classes="paragraph-gray">Gibt deinem Vortrag einen Titel. Er sollte kurz, aber auch spannend sein,
             sodass er „Lust auf mehr” macht, ohne zu viel zu verraten.
         </Paragraph>
@@ -92,7 +96,7 @@
                   bind:value={data.description}
                   on:input={setUnsavedChanges}
                   on:submit={save}
-                  limit={isAdmin ? NO_LIMIT : 280}/>
+                  limit={isAdmin ? NO_LIMIT : DESCRIPTION_LIMIT}/>
         <Paragraph classes="paragraph-gray">Beschreibe deinen Vortrag. Hier darfst du gerne etwas mehr ins Detail gehen.
             Worum geht es in deinem Vortrag? Was wird man dabei lernen? Was ist das
             Besondere an deinem Vortrag? Eine

--- a/src/forms/speakerTalkForm.svelte
+++ b/src/forms/speakerTalkForm.svelte
@@ -78,7 +78,8 @@
                labelText="Titel:"
                ariaLabel="Gib hier den Titel des Talks ein"
                bind:value={data.title}
-               on:input={setUnsavedChanges}/>
+               on:input={setUnsavedChanges}
+               limit={100-28-data.speaker.name.length}/>
         <Paragraph classes="paragraph-gray">Gibt deinem Vortrag einen Titel. Er sollte kurz, aber auch spannend sein,
             sodass er „Lust auf mehr” macht, ohne zu viel zu verraten.
         </Paragraph>

--- a/src/forms/speakerTalkForm.svelte
+++ b/src/forms/speakerTalkForm.svelte
@@ -22,9 +22,9 @@
     import FormWrapper from 'elements/wrapper/formWrapper.svelte';
     import Paragraph from 'elements/text/paragraph.svelte';
 
-    const YOUTUBE_VIDEO_TITLE_LENGTH = 100;
-    const YOUTUBE_VIDEO_TITLE_FIXED_PART = " –  – TECH STREAM CONFERENCE"
-    const DESCRIPTION_LIMIT = 280;
+    const YOUTUBE_VIDEO_TITLE_MAX_LENGTH = 100;
+    const YOUTUBE_VIDEO_TITLE_FIXED_PART = " –  – TECH STREAM CONFERENCE";
+    const TALK_DESCRIPTION_MAX_LENGTH = 280;
 
     export let classes: string = '';
     export let data: DashboardPendingTalk;
@@ -85,7 +85,7 @@
                ariaLabel="Gib hier den Titel des Talks ein"
                bind:value={data.title}
                on:input={setUnsavedChanges}
-               limit={YOUTUBE_VIDEO_TITLE_LENGTH-YOUTUBE_VIDEO_TITLE_FIXED_PART.length-data.speaker.name.length}/>
+               limit={YOUTUBE_VIDEO_TITLE_MAX_LENGTH-YOUTUBE_VIDEO_TITLE_FIXED_PART.length-data.speaker.name.length}/>
         <Paragraph classes="paragraph-gray">Gibt deinem Vortrag einen Titel. Er sollte kurz, aber auch spannend sein,
             sodass er „Lust auf mehr” macht, ohne zu viel zu verraten.
         </Paragraph>
@@ -96,7 +96,7 @@
                   bind:value={data.description}
                   on:input={setUnsavedChanges}
                   on:submit={save}
-                  limit={isAdmin ? NO_LIMIT : DESCRIPTION_LIMIT}/>
+                  limit={isAdmin ? NO_LIMIT : TALK_DESCRIPTION_MAX_LENGTH}/>
         <Paragraph classes="paragraph-gray">Beschreibe deinen Vortrag. Hier darfst du gerne etwas mehr ins Detail gehen.
             Worum geht es in deinem Vortrag? Was wird man dabei lernen? Was ist das
             Besondere an deinem Vortrag? Eine

--- a/src/routes/dashboard/admin/create-panel-discussion/+page.svelte
+++ b/src/routes/dashboard/admin/create-panel-discussion/+page.svelte
@@ -108,7 +108,8 @@
             <SpeakerTalkForm bind:data={talkData}
                              tags={data.tags}
                              talkDurations={data.durations}
-                             useForm={false}/>
+                             useForm={false}
+                             isAdmin={true}/>
             <PersonArray labelText="Mögliche Hosts:"
                          bind:selected={selectedHosts}
                          data={data.possibleHosts}/>


### PR DESCRIPTION
close #300

As said in the issue.
We should maybe restrict ourselves while writing a panel discussion description.
The first part of the description could be as long as a speaker description and rather stand alone. 

What do you think? 