### PR TITLE
fix: trigger shedule to update content

### DIFF
--- a/src/pages/year.svelte
+++ b/src/pages/year.svelte
@@ -87,6 +87,7 @@
 
         return Object.values(dict);
     }
+
     function isEventOver(): boolean {
         const today = new Date();
         today.setHours(0, 0, 0, 0);
@@ -278,18 +279,20 @@
                         </div>
                     {/if}
                     <div class="year-section-inner">
-                        {#each splitTalks() as days}
-                            <Schedule
-                                    schedule={days.normal}
-                                    speakers={data.year.speakers}
-                                    personPopupCallback={openPersonPopup}
-                            />
-                            <Schedule
-                                    schedule={days.special}
-                                    speakers={data.year.speakers}
-                                    personPopupCallback={openPersonPopup}
-                            />
-                        {/each}
+                        {#key data.year.event.id}
+                            {#each splitTalks() as days}
+                                <Schedule
+                                        schedule={days.normal}
+                                        speakers={data.year.speakers}
+                                        personPopupCallback={openPersonPopup}
+                                />
+                                <Schedule
+                                        schedule={days.special}
+                                        speakers={data.year.speakers}
+                                        personPopupCallback={openPersonPopup}
+                                />
+                            {/each}
+                        {/key}
                     </div>
                 {:else}
                     <div class="year-section-inner">


### PR DESCRIPTION
An here are the two lines of code I wrote the new seeder for. LUL

Im now checking if the event ID did change and force Svelte to update the Schedule then. 
It seams to work quite nice.

It would be nice to deploy this fix maybe before the conference, since there where some people in my stream who reported that.
If its not possible. That will be fine too.