### PR TITLE
fix: use flex instead of subgrid

### DIFF
--- a/src/elements/person/personRectangle.svelte
+++ b/src/elements/person/personRectangle.svelte
@@ -48,9 +48,8 @@
 
 <style>
     .person-rectangle {
-        display: grid;
-        grid-template-rows: subgrid;
-        grid-row: span 6;
+        display: flex;
+        flex-direction: column;
         outline: 1px solid var(--primary-color-light);
         border-radius: var(--border-radius);
         text-align: center;
@@ -76,6 +75,7 @@
         line-clamp: 3;
         -webkit-box-orient: vertical;
         overflow: hidden;
+        height: 8.5rem;
     }
 
     .person-rectangle-line {
@@ -85,6 +85,7 @@
     :global(.person-rectangle-button) {
         margin-bottom: var(--full-margin);
         width: calc(100% - 2 * var(--full-margin));
+        margin-top: auto;
     }
 
     :global(.person-rectangle-margin) {


### PR DESCRIPTION
I removed the `subgrid` from the speaker and team rectangle since firefox has an bug within computing the correct height of the `subgrid` entriy.
It seams that firefox is always using the hardcoded picture height (350px) and not the computed height. Witch can be up to 700px in our case. 
This leads to ether having broken a rectangle but the next headline is rendered correctly:
Or in having a Correct rectangle but the next headline is broken:  

So now I switched to a `felx` layout. Sadly the rectangles are no longer syncing by now since that is the main feature of `subgrid`.
So now the subheadline has a fixed height. That leads to some space when the subheadline is not that long.
And the button has a automatic margin so that the button stays at the bottom the rectangle.

This affects firefox users with a resolution up to FullHD in width.
So I would leave that up to you if you want to deploy this fix bevor Test-Conf or not.
I think most people will not notice. Basically the issue appears on Mobile and upright screens.

close #298 
close #297 
